### PR TITLE
do not set default password for system user

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,13 +28,10 @@ class wildfly::install(
     ensure => present,
   }
 
-  # http://raftaman.net/?p=1311 for generating password
-  # password = wildfly
   user { $user :
     ensure     => present,
     groups     => $group,
     shell      => '/bin/bash',
-    password   => '$1$d0AuSVPS$WhuUjhtX3ejUHxQQImEkk/',
     home       => "/home/${user}",
     comment    => "${user} user created by Puppet",
     managehome => true,


### PR DESCRIPTION
Hi, thanks for the great puppet module, saved me some time setting up wildfly. Still I think setting a default password for an user account is a bit insecure on production systems, so I request to merge this rather small change.
