### PR TITLE
init script expects default config in /etc/default/wildfly

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,7 +3,7 @@
 #
 class wildfly::service {
 
-  file { '/etc/default/wildfly.conf':
+  file { '/etc/default/wildfly':
     ensure  => present,
     mode    => '0755',
     owner   => 'root',
@@ -24,7 +24,7 @@ class wildfly::service {
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
-    require    => [File['/etc/init.d/wildfly'],File['/etc/default/wildfly.conf']]
+    require    => [File['/etc/init.d/wildfly'],File['/etc/default/wildfly']]
   }
 
 }


### PR DESCRIPTION
Using a install location different from /opt/wildfly the init script is unable to find wildfly, because /etc/default/wildfly is not there. At least on debian this fix works, but I guess its the same for other OS's init scripts. 