### PR TITLE
Improves deploy to support both URL and Nexus sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ Source supports: http://, ftp://, file://
      source   => 'http://central.maven.org/maven2/io/hawt/hawtio-web/1.4.48/hawtio-web-1.4.48.war',
      checksum => '303e8fcb569a0c3d33b7c918801e5789621f6639' #sha1
     }
+    
+**From Nexus:**
+
+    wildfly::standalone::deploy { 'hawtio.war':
+      ensure     => present,
+      nexus_url  => 'https://oss.sonatype.org',
+      gav        => 'io.hawt:hawtio-web:1.4.36',
+      repository => 'releases',
+      packaging  => 'war',
+    }
 
 ## User management
 
@@ -134,8 +144,7 @@ Setup a driver and a datasource:
       driver_xa_datasource_class_name => 'org.postgresql.xa.PGXADataSource'
     }
     ->
-    wildfly::standalone::datasources::datasource { 'Demo datasource':
-      name           => 'DemoDS',
+    wildfly::standalone::datasources::datasource { 'DemoDS':
       config         => {
         'driver-name' => 'postgresql',
         'connection-url' => 'jdbc:postgresql://localhost/postgres',
@@ -209,7 +218,7 @@ Datasource configuration uses a hash with elements that match JBoss-CLI datasour
 
 ## Server Reload
 
-Some configurations like SSL and modcluster requires a server reload, it can be achieved with the following define:
+Some configurations like SSL and modcluster requires a server reload, it can be achieved with the following snippet:
 
     wildfly::util::exec_cli { 'Reload if necessary':
       command => 'reload',

--- a/manifests/config/module.pp
+++ b/manifests/config/module.pp
@@ -3,7 +3,7 @@
 #
 define wildfly::config::module($source = undef, $dependencies = []) {
 
-  require jboss::install
+  require wildfly::install
 
   $namespace_path = regsubst($name, '[.]', '/', 'G')
 


### PR DESCRIPTION
It's working only locally cause archive has a small issue: https://github.com/puppet-community/puppet-archive/issues/56

As soon as it's fixed I'll ask for a new archive tag (0.3.1) and update metadata.json