### PR TITLE
Manage user

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This module requires a JVM ( should already be there )
 - version           8.2.0
 - install_source    http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final.tar.gz
 - java_home         /usr/java/jdk1.7.0_75/ (default dir for oracle official rpm)
+- manage_user       true
 - group             wildfly
 - user              wildfly
 - dirname           /opt/wildfly

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@ class wildfly(
   $version           = '8.2.0',
   $install_source    = 'http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final.tar.gz',
   $java_home         = $wildfly::params::java_home,
+  $manage_user       = $wildfly::params::manage_user,
   $group             = $wildfly::params::group,
   $user              = $wildfly::params::user,
   $dirname           = $wildfly::params::dirname,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,9 +3,10 @@
 #
 class wildfly::params {
 
-  $group   = 'wildfly'
-  $user    = 'wildfly'
-  $dirname = '/opt/wildfly'
+  $manage_user = true
+  $group       = 'wildfly'
+  $user        = 'wildfly'
+  $dirname     = '/opt/wildfly'
 
   $service_file  = $::osfamily? {
     'Debian' => 'wildfly-init-debian.sh',

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -3,19 +3,21 @@
 #
 class wildfly::prepare {
 
-  ## extract user prepare
-  group { $wildfly::group :
-    ensure => present,
-  }
+  if $wildfly::manage_user {
+    ## extract user prepare
+    group { $wildfly::group :
+      ensure => present,
+    }
 
-  user { $wildfly::user :
-    ensure     => present,
-    groups     => $wildfly::group,
-    shell      => '/bin/bash',
-    home       => "/home/${wildfly::user}",
-    comment    => "${wildfly::user} user created by Puppet",
-    managehome => true,
-    require    => Group[$wildfly::group],
+    user { $wildfly::user :
+      ensure     => present,
+      groups     => $wildfly::group,
+      shell      => '/bin/bash',
+      home       => "/home/${wildfly::user}",
+      comment    => "${wildfly::user} user created by Puppet",
+      managehome => true,
+      require    => Group[$wildfly::group],
+    }
   }
 
   # extract dir


### PR DESCRIPTION
In my environment I need to control the gid/uid of the user used for wildfly. I've added a `manage_user` flag so that users can choose whether or not they want to manage wildfly's user themselves.