### PR TITLE
Support template variable declarations for puppet 4

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,6 +3,8 @@
 #
 class wildfly::install  {
 
+  $install_source = $wildfly::install_source
+
   $install_file = inline_template('<%=File.basename(URI::parse(@install_source).path)%>')
 
   archive { "/tmp/${install_file}":

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,6 +3,13 @@
 #
 class wildfly::service {
 
+  $java_home = $wildfly::java_home
+  $dirname = $wildfly::dirname
+  $user= $wildfly::user
+  $mode= $wildfly::mode
+  $config= $wildfly::config
+  $console_log=$wildfly::console_log
+
   case $::osfamily {
     'RedHat': {
       $wildfly_conf_file = '/etc/default/wildfly.conf'


### PR DESCRIPTION
In puppet 4 templates cannot just automatically get the non qualified paths of variables, and will error.

You have to declare the variables in the class to the fully qualified path.

I don't know if this is the best approach but this change makes the template calls work correctly.