### PR TITLE
Changes to allow wildfly module to deploy jboss EAP.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,17 +1,24 @@
 #
 # Wildfly default params class
 #
-class wildfly::params {
+class wildfly::params (
+  $custom_service_file = undef # can be set by hiera to override the default service file location
+) {
 
   $manage_user = true
   $group       = 'wildfly'
   $user        = 'wildfly'
   $dirname     = '/opt/wildfly'
 
-  $service_file  = $::osfamily? {
-    'Debian' => 'wildfly-init-debian.sh',
-    'RedHat' => 'wildfly-init-redhat.sh',
-    default  => 'wildfly-init-redhat.sh',
+  if $custom_service_file != undef {
+	$service_file = $custom_service_file
+  }
+  else {
+    $service_file  = $::osfamily? {
+      'Debian' => 'wildfly-init-debian.sh',
+      'RedHat' => 'wildfly-init-redhat.sh',
+      default  => 'wildfly-init-redhat.sh',
+    }
   }
 
   $java_home         = '/usr/java/jdk1.7.0_75/'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@ class wildfly::params (
   $dirname     = '/opt/wildfly'
 
   if $custom_service_file != undef {
-	$service_file = $custom_service_file
+    $service_file = $custom_service_file
   }
   else {
     $service_file  = $::osfamily? {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,10 @@
 #
 # Wildfly startup service class
 #
-class wildfly::service {
+class wildfly::service (
+	$custom_wildfly_conf_file = undef, # can be set by hiera to override the default conf file location
+	$service_name = "wildfly"
+){
 
   $java_home = $wildfly::java_home
   $dirname = $wildfly::dirname
@@ -10,15 +13,20 @@ class wildfly::service {
   $config= $wildfly::config
   $console_log=$wildfly::console_log
 
-  case $::osfamily {
-    'RedHat': {
-      $wildfly_conf_file = '/etc/default/wildfly.conf'
-    }
-    'Debian': {
-      $wildfly_conf_file = '/etc/default/wildfly'
-    }
-    default: {
-      $wildfly_conf_file = '/etc/default/wildfly.conf'
+  if $custom_wildfly_conf_file != undef {
+	$wildfly_conf_file = $custom_wildfly_conf_file
+  }
+  else {
+    case $::osfamily {
+      'RedHat': {
+        $wildfly_conf_file = "/etc/default/${service_name}.conf"
+      }
+      'Debian': {
+        $wildfly_conf_file = "/etc/default/${service_name}"
+      }
+      default: {
+        $wildfly_conf_file = "/etc/default/${service_name}.conf"
+      }
     }
   }
 
@@ -30,7 +38,7 @@ class wildfly::service {
     content => template('wildfly/wildfly.conf.erb'),
   }
 
-  file { '/etc/init.d/wildfly':
+  file { "/etc/init.d/${service_name}":
     ensure => present,
     mode   => '0755',
     owner  => 'root',
@@ -38,12 +46,12 @@ class wildfly::service {
     source => "${wildfly::dirname}/bin/init.d/${wildfly::service_file}",
   }
 
-  service { 'wildfly':
+  service { $service_name:
     ensure     => true,
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
-    require    => [File['/etc/init.d/wildfly'],File[$wildfly_conf_file]]
+    require    => [File["/etc/init.d/${service_name}"],File[$wildfly_conf_file]]
   }
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,8 +2,8 @@
 # Wildfly startup service class
 #
 class wildfly::service (
-	$custom_wildfly_conf_file = undef, # can be set by hiera to override the default conf file location
-	$service_name = "wildfly"
+    $custom_wildfly_conf_file = undef, # can be set by hiera to override the default conf file location
+    $service_name = 'wildfly'
 ){
 
   $java_home = $wildfly::java_home
@@ -14,7 +14,7 @@ class wildfly::service (
   $console_log=$wildfly::console_log
 
   if $custom_wildfly_conf_file != undef {
-	$wildfly_conf_file = $custom_wildfly_conf_file
+    $wildfly_conf_file = $custom_wildfly_conf_file
   }
   else {
     case $::osfamily {


### PR DESCRIPTION
Wildfly and jboss EAP are currently pretty similar in structure. With a couple of small tweaks to this module you can get it to deploy EAP. I realise in the future they may diverge, but for now these changes allow you to use this module to deploy jboss EAP.

I'm aware my solution isn't great; the changes I'm submitting are basically the mimunum that are required (and could be made easier to use), but I'm submitting this pull request because I think they might be useful to other people.

My changes are just to expose a few parameters that can be set using hiera:

    wildfly::service::service_name: jboss-as
    wildfly::service::custom_wildfly_conf_file: /etc/jboss-as/jboss-as.conf
    wildfly::params::custom_service_file: jboss-as-standalone.sh
    wildfly::install_source: http://mywebserver/jboss-eap-6.1.tar.gz

Annoyingly [EAP ](http://www.jboss.org/products/eap/download/) doesn't have a tag.gz, it only comes in a zip, so what I've been doing is unpacking the zip, stripping out the top directory and then repackging as a tar.gz... Then I dump the file somewhere (filesystem or webserver etc) and reference it as an install source. Sounds like a faff but they don't release a new version of jboss that often.

I've been using EAP 6.1, so that's all I've tested with so far.