### PR TITLE
Changes to memory settings (for example) aren't applied until a manual restart of the service

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -13,7 +13,8 @@ class wildfly::setup (
     ensure  => file,
     owner   => $wildfly::user,
     group   => $wildfly::group,
-    content => template('wildfly/standalone.conf.erb')
+    content => template('wildfly/standalone.conf.erb'),
+    notify  => Class['wildfly::service']
   }
 
   # interfaces


### PR DESCRIPTION
I noticed that if I changed the memory settings, the change was applied to the `standalone.conf` file, but the service wasn't restarted, thus the change in settings wouldn't actually be applied until a manual restart. I'm not 100% about the cause of this, but one solution is as I've done in this PR, which is to make the `file` resource that's updating the `standalone.conf` notify the service - causing it to restart if the file has changed.