### PR TITLE
Support escaped slashes in resource names

### DIFF
--- a/lib/puppet_x/util/wildfly_cli_assembler.rb
+++ b/lib/puppet_x/util/wildfly_cli_assembler.rb
@@ -2,10 +2,13 @@ module WildflyCliAssembler
   def assemble_address(resource)
     address = []
 
-    resource.split('/').each do |token|
+    escaped_slash = "__ESCAPED__"
+    escaped_resource = resource.gsub(/\\\//, escaped_slash)
+
+    escaped_resource.split('/').each do |token|
       node_type, node_name = token.split('=')
       unless node_type.nil? && node_name.nil?
-        address << { node_type => node_name }
+        address << { node_type => (node_name.nil? ? nil : node_name.gsub(escaped_slash, "/")) }
       end
     end
 


### PR DESCRIPTION
Addresses Issue #46:

Resources with a slash can be managed by escaping the slash. We then
replace the escaped value with a dummy before splitting and replace it
later. This allows a resource such as
'/subsystem=undertow/server=default-server/host=default-host/location=\/'
to be managed.