### PR TITLE
Support ensure parameter in resource util

### DIFF
--- a/manifests/util/resource.pp
+++ b/manifests/util/resource.pp
@@ -1,7 +1,7 @@
 #
 # Uses wildfly_resource to ensure configuration state
 #
-define wildfly::util::resource($content = undef, $recursive = false) {
+define wildfly::util::resource($content = undef, $recursive = false, $ensure = 'present') {
 
   wildfly_resource { $name:
     username  => $::wildfly::users_mgmt['wildfly']['username'],
@@ -9,7 +9,8 @@ define wildfly::util::resource($content = undef, $recursive = false) {
     host      => $::wildfly::mgmt_bind,
     port      => $::wildfly::mgmt_http_port,
     recursive => $recursive,
-    state     => $content
+    state     => $content,
+    ensure    => $ensure
   }
 
 }


### PR DESCRIPTION
Addresses #45

Add the ensure parameter to the wildfly::util::resource definition so
its ensurable can be managed.