### PR TITLE
Support installing non-system modules

### DIFF
--- a/manifests/config/module.pp
+++ b/manifests/config/module.pp
@@ -1,18 +1,24 @@
 #
 # Module installation
 #
-define wildfly::config::module($source = undef, $dependencies = []) {
+define wildfly::config::module($source = undef, $dependencies = [], $system = true) {
 
   require wildfly::install
 
   $namespace_path = regsubst($name, '[.]', '/', 'G')
+  if $system {
+    $module_dir = "system/layers/base"
+  }
+  else {
+    $module_dir = ""
+  }
 
   File {
     owner => $wildfly::user,
     group => $wildfly::group
   }
 
-  $dir_path = "${wildfly::dirname}/modules/system/layers/base/${namespace_path}/main"
+  $dir_path = "${wildfly::dirname}/modules/${module_dir}/${namespace_path}/main"
 
   exec { "Create Parent Directories: ${name}":
     path    => ['/bin','/usr/bin', '/sbin'],


### PR DESCRIPTION
Addresses Issue #44 
Add support for installing modules to the root modules directory instead
of the system so it does not collide with system modules. The default
module type is still system to be consistent with existing usage.