### PR TITLE
exec_cli support for conditions with arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ pkg
 .bundle/config
 .idea
 /log
+*.iml
 
 *.lock
 .vagrant

--- a/lib/puppet/provider/wildfly_cli/http_api.rb
+++ b/lib/puppet/provider/wildfly_cli/http_api.rb
@@ -31,12 +31,15 @@ Puppet::Type.type(:wildfly_cli).provide(:http_api) do
   def evaluate_command(command)
     condition, command = command.split(/\sof\s/)
     variable, operator, value = condition.sub('(', '').sub(')', '').split(/\s/)
+    response = cli.exec(command)
 
     debug "Executing: #{command} to verify: (#{condition})"
 
-    response = cli.exec(command)
-
-    condition = "'#{response[variable]}' #{operator} '#{value}'"
+    if operator == 'has'
+      condition = "#{response[variable].inspect}.include?(#{value})"
+    else
+      condition = "'#{response[variable]}' #{operator} '#{value}'"
+    end
 
     debug "Condition (#{condition})"
 


### PR DESCRIPTION
Hi, I modified http_api.rb to support statements like

    unless  => '(result has "Monitor") of /core-service=management/access=authorization:read-children-names(child-type=role-mapping)'
where result is an array