### PR TITLE
Allow for merging old properties into new resource

### DIFF
--- a/lib/puppet/provider/wildfly_resource/http_api.rb
+++ b/lib/puppet/provider/wildfly_resource/http_api.rb
@@ -34,9 +34,9 @@ Puppet::Type.type(:wildfly_resource).provide(:http_api) do
   def state=(value)
     debug "Updating state for: #{@resource[:path]} with #{@resource[:state].inspect}"
     if @resource[:recursive]
-      cli.update_recursive(@resource[:path], value)
+      cli.update_recursive(@resource[:path], value, @resource[:merge_on_update])
     else
-      cli.update(@resource[:path], value)
+      cli.update(@resource[:path], value, @resource[:merge_on_update])
     end
   end
 end

--- a/lib/puppet/type/wildfly_resource.rb
+++ b/lib/puppet/type/wildfly_resource.rb
@@ -37,6 +37,11 @@ Puppet::Type.newtype(:wildfly_resource) do
     defaultto false
   end
 
+  newparam(:merge_on_update) do
+    desc 'Merge properties on update. Defaults to false'
+    defaultto false
+  end
+
   newproperty(:state) do
     desc 'Resource state'
     defaultto {}

--- a/lib/puppet_x/util/wildfly_cli.rb
+++ b/lib/puppet_x/util/wildfly_cli.rb
@@ -79,7 +79,12 @@ module PuppetX
         response['outcome'] == 'success' ? response['result'] : {}
       end
 
-      def update_recursive(resource, state)
+      def update_recursive(resource, state, merge = false)
+        if merge
+          old_state = read(resource, true)
+          state = recursive_merge_state(old_state, state)
+        end
+
         remove = {
           :address => assemble_address(resource),
           :operation => :remove
@@ -98,7 +103,11 @@ module PuppetX
         send(composite)
       end
 
-      def update(resource, state)
+      def update(resource, state, merge = false)
+        if merge
+           state = read(resource).merge(state)
+        end
+
         remove = {
           :address => assemble_address(resource),
           :operation => :remove
@@ -182,6 +191,17 @@ module PuppetX
       end
 
       private
+
+      def recursive_merge_state(old_state, new_state)
+        map_list = new_state.map do |k,v|
+          if v.is_a?(Hash) and old_state.fetch(k, nil).is_a?(Hash)
+            { k => recursive_merge_state(old_state[k], v) }
+          else
+            { k => v }
+          end
+        end
+        old_state.reject {|k,v| v == nil}.merge(Hash[map_list])
+      end
 
       def split_resources(name, state)
         # Ruby 1.8.7 Hash doesn't have filter

--- a/manifests/datasources/xa_datasource.pp
+++ b/manifests/datasources/xa_datasource.pp
@@ -6,9 +6,10 @@ define wildfly::datasources::xa_datasource($config = undef, $target_profile = un
   $profile_path = profile_path($target_profile)
 
   wildfly::util::resource { "/subsystem=datasources/xa-data-source=${name}":
-    content   => $config,
-    recursive => true,
-    profile   => $target_profile,
+    content         => $config,
+    recursive       => true,
+    merge_on_update => true,
+    profile         => $target_profile,
   }
   ->
   wildfly::util::exec_cli { "Enable ${name}":

--- a/manifests/util/resource.pp
+++ b/manifests/util/resource.pp
@@ -1,18 +1,19 @@
 #
 # Uses wildfly_resource to ensure configuration state
 #
-define wildfly::util::resource($ensure = 'present', $content = undef, $recursive = false, $profile = undef) {
+define wildfly::util::resource($ensure = 'present', $content = undef, $recursive = false, $merge_on_update = false, $profile = undef) {
 
   $profile_path = profile_path($profile)
 
   wildfly_resource { "${profile_path}${name}":
-    ensure    => $ensure,
-    username  => $::wildfly::users_mgmt['wildfly']['username'],
-    password  => $::wildfly::users_mgmt['wildfly']['password'],
-    host      => $::wildfly::mgmt_bind,
-    port      => $::wildfly::mgmt_http_port,
-    recursive => $recursive,
-    state     => $content,
+    ensure          => $ensure,
+    username        => $::wildfly::users_mgmt['wildfly']['username'],
+    password        => $::wildfly::users_mgmt['wildfly']['password'],
+    host            => $::wildfly::mgmt_bind,
+    port            => $::wildfly::mgmt_http_port,
+    recursive       => $recursive,
+    merge_on_update => $merge_on_update,
+    state           => $content,
   }
 
 }


### PR DESCRIPTION
Updates to resources by the wildfly module are destructive. Add an option to allow the preservation of properties from the old state during update.

I realize as I'm writing this that it would probably be better to achieve this by having an option to make updates destructive or non-destructive. I'm going to leave this PR as is to get feedback and because I've merged it into our fork. I may look at doing this better later.
