### PR TITLE
Allow for new wildfly versions to be extracted

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,11 +7,12 @@ class wildfly::install  {
 
   $install_file = inline_template('<%=File.basename(URI::parse(@install_source).path)%>')
 
-  archive { "/tmp/${install_file}":
+  archive { "/{wildfly::dirname}/${install_file}":
     source        => $wildfly::install_source,
     extract       => true,
     extract_path  => $wildfly::dirname,
-    creates       => "${wildfly::dirname}/jboss-modules.jar",
+    creates       => "${wildfly::dirname}/${install_file}",
+    cleanup       => false,
     user          => $wildfly::user,
     group         => $wildfly::group,
     extract_flags => '--strip-components=1 -zxf'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,7 +7,7 @@ class wildfly::install  {
 
   $install_file = inline_template('<%=File.basename(URI::parse(@install_source).path)%>')
 
-  archive { "/{wildfly::dirname}/${install_file}":
+  archive { "/${wildfly::dirname}/${install_file}":
     source        => $wildfly::install_source,
     extract       => true,
     extract_path  => $wildfly::dirname,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,7 +7,7 @@ class wildfly::install  {
 
   $install_file = inline_template('<%=File.basename(URI::parse(@install_source).path)%>')
 
-  archive { "/${wildfly::dirname}/${install_file}":
+  archive { "${wildfly::dirname}/${install_file}":
     source        => $wildfly::install_source,
     extract       => true,
     extract_path  => $wildfly::dirname,

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -11,7 +11,8 @@ describe 'wildfly::install' do
       should contain_archive('/tmp/wildfly-8.2.0.Final.tar.gz').with(
         'extract' => true,
         'extract_path' => '/opt/wildfly',
-        'creates' => '/opt/wildfly/jboss-modules.jar',
+        'creates' => '/opt/wildfly/wildfly-8.2.0.Final.tar.gz',
+        'cleanup' => false,
         'user' => 'wildfly',
         'group' => 'wildfly',
         'extract_flags' => '--strip-components=1 -zxf'

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -8,7 +8,7 @@ describe 'wildfly::install' do
   context 'install wildfly' do
     it { should contain_class('wildfly::install') }
     it do
-      should contain_archive('/tmp/wildfly-8.2.0.Final.tar.gz').with(
+      should contain_archive('/opt/wildfly/wildfly-8.2.0.Final.tar.gz').with(
         'extract' => true,
         'extract_path' => '/opt/wildfly',
         'creates' => '/opt/wildfly/wildfly-8.2.0.Final.tar.gz',


### PR DESCRIPTION
The old code relied on archive's create parameter to know when to run.
Unfortunately it passed the extracted file path to creates and this path
does not change even when you want a new version of wildfly. This mean
that you could not upgrade wildfly using this module without performing
some other act to move the jar aside.

Fix this by not cleaning up the archive file and setting creates to be
the preextracted filename which should be unique per wildfly version.
This has the downside of never cleaning up the archives but using up a
bit of disk space seems preferable to not being able to upgrade
automagically.
