### PR TITLE
Safely require curl package in prepare.pp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Acceptance tests works with **puppetlabs/java** in both CentOS and Debian.
 ## Module defaults
 - version           8.2.1
 - install_source    http://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final.tar.gz
+- install_curl      true
 - java_home         /usr/java/jdk1.7.0_75/ (default dir for oracle official rpm)
 - manage_user       true
 - group             wildfly

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 class wildfly(
   $version           = '8.2.1',
   $install_source    = 'http://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final.tar.gz',
+  $install_curl      = $wildfly::params::install_curl,
   $java_home         = $wildfly::params::java_home,
   $manage_user       = $wildfly::params::manage_user,
   $uid               = $wildfly::params::uid,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@
 #
 class wildfly::params {
 
+  $install_curl = true
   $manage_user  = true
   $uid          = undef
   $gid          = undef

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -2,8 +2,7 @@
 # Wildlfy prepare class
 #
 class wildfly::prepare {
-  package {'curl': ensure => present, }
-  
+
   if $wildfly::manage_user {
 
     group { $wildfly::group :
@@ -40,6 +39,12 @@ class wildfly::prepare {
 
   if !defined(Package[$libaiopackage]) {
     package { $libaiopackage:
+      ensure => present,
+    }
+  }
+
+  if !defined(Package['curl']) {
+    package { 'curl':
       ensure => present,
     }
   }

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -43,7 +43,7 @@ class wildfly::prepare {
     }
   }
 
-  if !defined(Package['curl']) {
+  if $wildfly::install_curl {
     package { 'curl':
       ensure => present,
     }

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">=3.2.0"
-    },
+    }
   ],
   "license": "Apache-2.0",
   "name": "biemond-wildfly",


### PR DESCRIPTION
Using this method instead of `ensure_packages()` because it matches the
existing code style.