### PR TITLE
change package resource for curl to function ensure_resource 

### DIFF
--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -2,7 +2,7 @@
 # Wildlfy prepare class
 #
 class wildfly::prepare {
-  package {'curl': ensure => present, }
+  ensure_resource('package', 'curl', {'ensure' => 'present'})
   
   if $wildfly::manage_user {
 


### PR DESCRIPTION
ensure_resource function from puppetlabs/stdlib can be used to avoid duplicate package declaration conflicts.