### PR TITLE
Make tarball installation directory configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 class wildfly(
   $version           = '9.0.2',
   $install_source    = 'http://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final.tar.gz',
+  $install_cache_dir = $wildfly::params::install_cache_dir,
   $java_home         = $wildfly::params::java_home,
   $manage_user       = $wildfly::params::manage_user,
   $uid               = $wildfly::params::uid,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,22 +4,22 @@
 class wildfly::install  {
 
   $install_source = $wildfly::install_source
-
+  $install_cache_dir = $wildfly::install_cache_dir
   $install_file = inline_template('<%=File.basename(URI::parse(@install_source).path)%>')
 
   # Download Wildfly from jboss.org
   exec { "Download wildfly from ${install_source}":
-    command  => "wget -N -P /var/cache/wget ${install_source} --max-redirect=5",
+    command  => "wget -N -P ${install_cache_dir} ${install_source} --max-redirect=5",
     path     => ['/bin', '/usr/bin', '/sbin'],
     loglevel => 'notice',
-    creates  => "/var/cache/wget/${install_file}",
+    creates  => "${install_cache_dir}/${install_file}",
     unless   => "test -f ${wildfly::dirname}/jboss-modules.jar",
     timeout  => 500,
   }
   ~>
   # Gunzip+Untar wildfly.tar.gz if download was successful.
   exec { "untar ${install_file}":
-    command  => "tar --no-same-owner --no-same-permissions --strip-components=1 -C ${wildfly::dirname} -zxvf /var/cache/wget/${install_file}",
+    command  => "tar --no-same-owner --no-same-permissions --strip-components=1 -C ${wildfly::dirname} -zxvf ${install_cache_dir}/${install_file}",
     path     => ['/bin', '/usr/bin', '/sbin'],
     loglevel => 'notice',
     creates  => "${wildfly::dirname}/jboss-modules.jar",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,5 +58,5 @@ class wildfly::params {
 
   $domain_slave = {}
   $custom_init  = undef
-
+  $install_cache_dir = '/var/cache/wget'
 }

--- a/test.sh
+++ b/test.sh
@@ -17,7 +17,7 @@ set -e
 ruby -v
 echo "gem version"
 gem --version
-gem install bundler --no-rdoc --no-ri
+gem install bundler --no-rdoc --no-ri --version 1.10.6
 bundle install --without development
 bundle --version
 gem update --system 2.1.11


### PR DESCRIPTION
changing the tarball download directory to /var/cache/wget is useful for the vagrant-cachier use case, but we need to actually set this to a different directory.

This PR keeps the existing defaults, but allows the download directory to be set explicitly.

Additionally, I've had to add a line to test.sh to explicitly set the bundler version. It doesn't appear that this project is compatible with bundler version > 1.11+