### PR TITLE
Setting Exec download timeout parametric

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@ class wildfly(
   $version                      = '9.0.2',
   $install_source               = 'http://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final.tar.gz',
   $install_cache_dir            = $wildfly::params::install_cache_dir,
+  $install_download_timeout     = $wildfly::params::install_download_timeout,
   $java_home                    = $wildfly::params::java_home,
   $manage_user                  = $wildfly::params::manage_user,
   $uid                          = $wildfly::params::uid,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,7 +14,7 @@ class wildfly::install  {
     loglevel => 'notice',
     creates  => "${install_cache_dir}/${install_file}",
     unless   => "test -f ${wildfly::dirname}/jboss-modules.jar",
-    timeout  => 500,
+    timeout  => $wildfly::install_download_timeout,
   }
   ~>
   # Gunzip+Untar wildfly.tar.gz if download was successful.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,4 +61,6 @@ class wildfly::params {
   $custom_init  = undef
   $install_cache_dir = '/var/cache/wget'
   $domain_controller_only = false
+  
+  $install_download_timeout = 500
 }


### PR DESCRIPTION
As said in #116 setting Exec timeout parametric for Wildfly download, could help in deploying other products from JBoss family downloadable from other URLs

I found it useful for Keycloak provisioning, which has a slow download rate that sometimes can invalidate installation due an Exec wget process timeout 