### PR TITLE
Add support for 'empty' module

### DIFF
--- a/spec/acceptance/acceptance_1_spec.rb
+++ b/spec/acceptance/acceptance_1_spec.rb
@@ -29,6 +29,10 @@ describe 'Acceptance case one. Standalone mode with defaults' do
             dependencies => ['javax.api', 'javax.transaction.api']
           }
 
+          wildfly::config::module { 'empty.module':
+            source       => '.'
+          }
+
           class { 'java': }
 
           Class['java'] -> Class['wildfly']
@@ -59,6 +63,15 @@ describe 'Acceptance case one. Standalone mode with defaults' do
       shell('ls -la /opt/wildfly/modules/system/layers/base/org/postgresql/main', :acceptable_exit_codes => 0) do |r|
         expect(r.stdout).to include 'postgresql-9.3-1103-jdbc4.jar'
         expect(r.stdout).to include 'module.xml'
+      end
+    end
+
+    it 'contains empty module' do
+      shell('ls -la /opt/wildfly/modules/system/layers/base/empty/module/main', :acceptable_exit_codes => 0) do |r|
+        expect(r.stdout).to include 'module.xml'
+      end
+      shell('cat /opt/wildfly/modules/system/layers/base/empty/module/main/module.xml', :acceptable_exit_codes => 0) do |r|
+        expect(r.stdout).to include '<resource-root path="."/>'
       end
     end
 


### PR DESCRIPTION
Allow 'empty' modules to be created. This is useful e.g. when you want to manage property files outside of the application deployment. 

for instance see: http://alibassam.com/how-to-read-properties-file-in-websphere-8-5-and-jboss-7/ , section 'JBoss 7'