### PR TITLE
Add enable property to SSL listener on Wfly >= 9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,4 +22,5 @@ gem 'fog-google', '= 0.1.0'
 gem 'beaker', '>= 2.0.0'
 gem 'beaker-rspec', '>= 5.0.0'
 gem 'serverspec', '>= 2.0.0'
+gem 'metadata-json-lint', '>= 0.0.11'
 

--- a/manifests/undertow/https.pp
+++ b/manifests/undertow/https.pp
@@ -3,6 +3,20 @@
 #
 define wildfly::undertow::https($socket_binding = undef, $keystore_path = undef, $keystore_password = undef, $key_alias = undef, $key_password = undef, $target_profile = undef) {
 
+  if versioncmp($wildfly::version,'9.0.0') >= 0 {
+    # Wildfly 9 and higher -> we need to set enable parameter
+    $listener_content = {
+      'socket-binding' => $socket_binding,
+      'security-realm' => 'TLSRealm',
+      'enable'         => true,
+    }
+  } else {
+    $listener_content = {
+      'socket-binding' => $socket_binding,
+      'security-realm' => 'TLSRealm',
+    }
+  }
+
   wildfly::util::resource { '/core-service=management/security-realm=TLSRealm':
     content => {},
   }
@@ -17,10 +31,7 @@ define wildfly::undertow::https($socket_binding = undef, $keystore_path = undef,
   }
   ->
   wildfly::util::resource { "/subsystem=undertow/server=default-server/https-listener=${name}":
-    content => {
-      'socket-binding' => $socket_binding,
-      'security-realm' => 'TLSRealm'
-    },
+    content => $listener_content,
     profile => $target_profile,
   }
 

--- a/manifests/undertow/https.pp
+++ b/manifests/undertow/https.pp
@@ -1,19 +1,23 @@
 #
 # Configures a connector
 #
-define wildfly::undertow::https($socket_binding = undef, $keystore_path = undef, $keystore_password = undef, $key_alias = undef, $key_password = undef, $target_profile = undef) {
+define wildfly::undertow::https($socket_binding = undef, $keystore_path = undef, $keystore_relative_to = undef, $keystore_password = undef, $key_alias = undef, $key_password = undef, $target_profile = undef, $enabled_protocols = undef, $enabled_cipher_suites = undef) {
 
   if versioncmp($wildfly::version,'9.0.0') >= 0 {
     # Wildfly 9 and higher -> we need to set enable parameter
     $listener_content = {
-      'socket-binding' => $socket_binding,
-      'security-realm' => 'TLSRealm',
-      'enable'         => true,
+      'socket-binding'        => $socket_binding,
+      'security-realm'        => 'TLSRealm',
+      'enabled-protocols'     => $enabled_protocols,
+      'enabled-cipher-suites' => $enabled_cipher_suites,
+      'enabled'               => true,
     }
   } else {
     $listener_content = {
-      'socket-binding' => $socket_binding,
-      'security-realm' => 'TLSRealm',
+      'socket-binding'        => $socket_binding,
+      'security-realm'        => 'TLSRealm',
+      'enabled-protocols'     => $enabled_protocols,
+      'enabled-cipher-suites' => $enabled_cipher_suites,
     }
   }
 
@@ -23,10 +27,11 @@ define wildfly::undertow::https($socket_binding = undef, $keystore_path = undef,
   ->
   wildfly::util::resource { '/core-service=management/security-realm=TLSRealm/server-identity=ssl':
     content => {
-      'keystore-path'     => $keystore_path,
-      'keystore-password' => $keystore_password,
-      'alias'             => $key_alias,
-      'key-password'      => $key_password
+      'keystore-path'        => $keystore_path,
+      'keystore-relative-to' => $keystore_relative_to,
+      'keystore-password'    => $keystore_password,
+      'alias'                => $key_alias,
+      'key-password'         => $key_password
     },
   }
   ->


### PR DESCRIPTION
I observed that SSL connections won't work on Wildfly 9, unless the `enabled` property on the https-listener is set to `true`.