### PR TITLE
Fixing wrong array usage

### DIFF
--- a/manifests/deployment.pp
+++ b/manifests/deployment.pp
@@ -41,7 +41,7 @@ define wildfly::deployment(
     ensure       => $ensure,
     server_group => $server_group,
     username     => $users_mgmt[0],
-    password     => $passwords_mgmt[0]['password'],
+    password     => $passwords_mgmt[0],
     host         => $::wildfly::mgmt_bind,
     port         => $::wildfly::mgmt_http_port,
     timeout      => $timeout,

--- a/manifests/util/exec_cli.pp
+++ b/manifests/util/exec_cli.pp
@@ -11,7 +11,7 @@ define wildfly::util::exec_cli(
 
   wildfly_cli { $name:
     username => $users_mgmt[0],
-    password => $passwords_mgmt[0]['password'],
+    password => $passwords_mgmt[0],
     host     => $::wildfly::mgmt_bind,
     port     => $::wildfly::mgmt_http_port,
     command  => $command,

--- a/manifests/util/reload.pp
+++ b/manifests/util/reload.pp
@@ -7,7 +7,7 @@ define wildfly::util::reload(
 
   wildfly_reload { $name:
     username => $users_mgmt[0],
-    password => $passwords_mgmt[0]['password'],
+    password => $passwords_mgmt[0],
     host     => $::wildfly::mgmt_bind,
     port     => $::wildfly::mgmt_http_port,
     retries  => $retries,

--- a/manifests/util/resource.pp
+++ b/manifests/util/resource.pp
@@ -14,7 +14,7 @@ define wildfly::util::resource(
   wildfly_resource { "${profile_path}${name}":
     ensure    => $ensure,
     username  => $users_mgmt[0],
-    password  => $passwords_mgmt[0]['password'],
+    password  => $passwords_mgmt[0],
     host      => $::wildfly::mgmt_bind,
     port      => $::wildfly::mgmt_http_port,
     recursive => $recursive,


### PR DESCRIPTION
I had some issues looking like this

``` bash
[root@ppbgows01 ~]# puppet apply wildfly.pp
Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Operator '[]' is not applicable to an Undef Value. at /etc/puppetlabs/code/environments/production/modules/wildfly/manifests/deployment.pp:44:21  at /root/wildfly.pp:52 on node ppbgows01
```

Turned out you're using the passwords_mgmt value() array like it's the key => value array $::wildfly::users_mgmt.

This PR fixed it on my server, didn't tried with multiples mgmt users or anything else.
