### PR TITLE
Change wildfly_cli should_execute? condition

### DIFF
--- a/lib/puppet/provider/wildfly_cli/http_api.rb
+++ b/lib/puppet/provider/wildfly_cli/http_api.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:wildfly_cli).provide(:http_api) do
       onlyif_eval = evaluate_command(@resource[:onlyif])
     end
 
-    onlyif_eval || !unless_eval
+    onlyif_eval || !unless_eval || (@resource[:unless].nil? && @resource[:onlyif].nil?)
   end
 
   def evaluate_command(command)


### PR DESCRIPTION
wildfly_cli should_execute? was returning false if both unless and onlyif are null. Return true if both are null.

If the intention is to require at least 1 condition, then the type should be changed to fail if both are null. 