### PR TITLE
Allow module to enable service, but not manage it.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class wildfly::params {
   $package_name     = undef
   $package_version  = present
 
-  $service_ensure    = true
+  $service_ensure    = undef
   $service_enable    = true
   $conf_file         = undef
   $service_file      = undef

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -20,7 +20,7 @@ describe 'wildfly::service' do
     it { is_expected.to contain_file('/etc/init.d/wildfly') }
     it do
       is_expected.to contain_service('wildfly').with(
-        'ensure'     => true,
+        'ensure'     => undef,
         'hasrestart' => true,
         'hasstatus'  => true
       )
@@ -42,7 +42,7 @@ describe 'wildfly::service' do
     it { is_expected.to contain_file('/etc/init.d/wildfly') }
     it do
       is_expected.to contain_service('wildfly').with(
-        'ensure'     => true,
+        'ensure'     => undef,
         'hasrestart' => true,
         'hasstatus'  => true
       )
@@ -65,7 +65,7 @@ describe 'wildfly::service' do
     it { is_expected.to contain_file('/etc/init.d/wildfly') }
     it do
       is_expected.to contain_service('wildfly').with(
-        'ensure'     => true,
+        'ensure'     => undef,
         'enable'     => true,
         'hasrestart' => true,
         'hasstatus'  => true

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -20,7 +20,6 @@ describe 'wildfly::service' do
     it { is_expected.to contain_file('/etc/init.d/wildfly') }
     it do
       is_expected.to contain_service('wildfly').with(
-        'ensure'     => undef,
         'hasrestart' => true,
         'hasstatus'  => true
       )
@@ -42,7 +41,6 @@ describe 'wildfly::service' do
     it { is_expected.to contain_file('/etc/init.d/wildfly') }
     it do
       is_expected.to contain_service('wildfly').with(
-        'ensure'     => undef,
         'hasrestart' => true,
         'hasstatus'  => true
       )
@@ -65,7 +63,6 @@ describe 'wildfly::service' do
     it { is_expected.to contain_file('/etc/init.d/wildfly') }
     it do
       is_expected.to contain_service('wildfly').with(
-        'ensure'     => undef,
         'enable'     => true,
         'hasrestart' => true,
         'hasstatus'  => true


### PR DESCRIPTION
When passing undef to service_ensure, it's ignored and assumed the default value of param, which is "true". When default value of $wildfly::params::service_ensure is undef, this module become more flexible because it's able to enable the service but not manage it.