### PR TITLE
Update documentation with working example of WildFly/Jboss reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ Or
 
 ```puppet
 wildfly::cli { 'Reload if necessary':
-  command => 'reload',
+  command => ':reload',
   onlyif  => '(result == reload-required) of :read-attribute(name=server-state)'
 }
 ```


### PR DESCRIPTION
I spent some hours to figure out why Wildfly::Cli['Reload if necessary'] I took from documentation was not working