### PR TITLE
Add deploy_cache_dir parameter as a location to store deployment files

### DIFF
--- a/manifests/deployment.pp
+++ b/manifests/deployment.pp
@@ -16,7 +16,11 @@ define wildfly::deployment(
 
   $file_name = inline_template('<%= File.basename(URI::parse(@source).path) %>')
 
-  file { "/opt/${file_name}":
+  file { $wildfly::deploy_cache_dir:
+    ensure => directory,
+  }
+
+  file { "${wildfly::deploy_cache_dir}/${file_name}":
     ensure => 'present',
     owner  => $wildfly::user,
     group  => $wildfly::group,
@@ -32,9 +36,9 @@ define wildfly::deployment(
     host              => $wildfly::setup::properties['jboss.bind.address.management'],
     port              => $wildfly::setup::properties['jboss.management.http.port'],
     timeout           => $timeout,
-    source            => "/opt/${file_name}",
+    source            => "${wildfly::deploy_cache_dir}/${file_name}",
     operation_headers => $operation_headers,
-    require           => [Service['wildfly'], File["/opt/${file_name}"]],
+    require           => [Service['wildfly'], File["${wildfly::deploy_cache_dir}/${file_name}"]],
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@
 # @param host_config Sets Wildfly Host configuration file for initialization when you're using 'domain' mode.
 # @param init_system Sets initsystem for service configuration.
 # @param install_cache_dir The directory to be used for wget cache.
+# @param deploy_cache_dir The directory to be used for deployment cache.
 # @param install_download_timeout Sets the timeout for installer download.
 # @param install_source Source of Wildfly tarball installer.
 # @param java_home Sets the `JAVA_HOME` for Wildfly.
@@ -55,6 +56,7 @@ class wildfly(
   Stdlib::Unixpath $java_home                                 = '/usr/java/default',
   Stdlib::Unixpath $console_log                               = '/var/log/wildfly/console.log',
   Stdlib::Unixpath $install_cache_dir                         = '/var/cache/wget',
+  Stdlib::Unixpath $deploy_cache_dir                          = '/opt',
   Boolean $manage_user                                        = true,
   String $user                                                = 'wildfly',
   String $group                                               = 'wildfly',


### PR DESCRIPTION
The hard-coded download location for deployments is /opt per deployments.pp.  On systems with large numbers of deployment files, /opt can be a bit cluttered.  This change is to add the deploy_cache_dir parameter.  Each instance of /opt in deployments.pp is replace with the new parameter and it is given a default value of /opt in init.pp.  This change will allow a custom directory to be specified in a profile for holding deployment files.