### PR TITLE
Add containment for subclasses in main class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,10 +107,10 @@ class wildfly(
   Optional[String] $jboss_opts                                = undef,
 ) {
 
-  include wildfly::prepare
-  include wildfly::install
-  include wildfly::setup
-  include wildfly::service
+  contain wildfly::prepare
+  contain wildfly::install
+  contain wildfly::setup
+  contain wildfly::service
 
   if $external_facts {
     include wildfly::external_facts


### PR DESCRIPTION
Prior to this commit, the main class used 'include' for the prepare, install,
setup, and service subclasses.  This commit updates that to use 'contain' so
that relationships can be drawn to Class['wildfly'] and have that relationship
also extend to the resources in the subclasses.