### PR TITLE
Fix 401 Unauthorized race

### DIFF
--- a/lib/puppet_x/wildfly/api_client.rb
+++ b/lib/puppet_x/wildfly/api_client.rb
@@ -36,6 +36,8 @@ module PuppetX
           retry
         end
 
+        sleep 0.05 # We've been returned an auth token.  But if we don't wait a small amount of time before using it, we might stil get a 401. :(
+
         if response['www-authenticate'] =~ /digest/i
           digest_auth.auth_header @uri, response['www-authenticate'], 'POST'
         else


### PR DESCRIPTION
This fixes an apparent race condition.  When using this module to
configure Keycloak 3.1.0, my puppet runs were previously failing about
50% of the time.

eg
```
Error: /Stage[main]/Main/Wildfly::Resource[/socket-binding-group=standard-sockets/socket-binding=proxy-https]/Wildfly_resource[/socket-binding-group=standard-sockets/socket-binding=proxy-https]: Could not evaluate: 757: unexpected token at '<html><head><title>Error</title></head><body>401 - Unauthorized</body></html>'
```

Inserting a small sleep is ugly, but it works.  I suppose you could try to catch the 401 and retry, but that would be quite a bit more code.  Let me know if this is what you'd prefer.

Thanks,
Alex