### PR TITLE
Fix 'title patterns that use procs are not supported'

### DIFF
--- a/lib/puppet/type/wildfly_resource.rb
+++ b/lib/puppet/type/wildfly_resource.rb
@@ -57,27 +57,26 @@ Puppet::Type.newtype(:wildfly_resource) do
   end
 
   def self.title_patterns
-    identity = lambda { |x| x }
     [
       [
         /^(.*):(.*):(.*)$/,
         [
-          [:path, identity],
-          [:host, identity],
-          [:port, identity]
+          [:path],
+          [:host],
+          [:port]
         ]
       ],
       [
         /^(.*):(.*)$/,
         [
-          [:path, identity],
-          [:host, identity]
+          [:path],
+          [:host]
         ]
       ],
       [
         /^([^:]+)$/,
         [
-          [:path, identity]
+          [:path]
         ]
       ]
     ]


### PR DESCRIPTION
This commit makes the module compatible with `puppet generate types`.

Fixes #226