### PR TITLE
Fix EL7 systemd unit file

### DIFF
--- a/files/launch.sh
+++ b/files/launch.sh
@@ -4,8 +4,11 @@ if [ "x$WILDFLY_HOME" = "x" ]; then
     WILDFLY_HOME="/opt/wildfly"
 fi
 
-if [[ "$1" == "domain" ]]; then
-    $WILDFLY_HOME/bin/domain.sh -c $2
+mode="$1"
+shift
+
+if [[ "$mode" == "domain" ]]; then
+    exec $WILDFLY_HOME/bin/domain.sh -c "$@"
 else
-    $WILDFLY_HOME/bin/standalone.sh -c $2
+    exec $WILDFLY_HOME/bin/standalone.sh -c "$@"
 fi

--- a/templates/wildfly.systemd.service.epp
+++ b/templates/wildfly.systemd.service.epp
@@ -1,16 +1,16 @@
 [Unit]
-Description=The WildFly Application Server
-After=syslog.target network.target
-Before=httpd.service
+Description=WildFly application server
+Wants=network-online.target
+After=network-online.target
 
 [Service]
-Environment=LAUNCH_JBOSS_IN_BACKGROUND=1
-EnvironmentFile=/etc/wildfly/wildfly.conf
 User=<%= $wildfly::user %>
+Group=<%= $wildfly::group %>
+EnvironmentFile=/etc/wildfly/wildfly.conf
 LimitNOFILE=102642
-PIDFile=/var/run/wildfly/wildfly.pid
-ExecStart=<%= $wildfly::dirname %>/bin/launch.sh $WILDFLY_MODE $WILDFLY_CONFIG
-StandardOutput=null
+ExecStart=<%= $wildfly::dirname %>/bin/launch.sh ${WILDFLY_MODE} ${WILDFLY_CONFIG}
+Restart=always
+RestartSec=20
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Without this patch wildfly fails to start on CentOS 7.  This patch
adds the following behaviors

 * systemd captures stdout error messages.
 * systemd attempts to restart the service.
 * The service is started robustly on boot once interfaces are fully
   configured.
 * systemctl status accurately reports the status of the service.