### PR TITLE
Add parameter overlay_class to apply a class between wildfly::install and wildfly::setup classes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,7 @@
 # @param mgmt_user Hash containing a Wildfly's management user to be used internally.
 # @param mode Sets Wildfly execution mode will run, 'standalone' or 'domain'.
 # @param mode_template Sets epp template for standalone.conf or domain.conf.
+# @param overlay_class Sets a class to be applied between 'install' and 'setup' classes.
 # @param package_ensure Wheter it should manage required packages.
 # @param package_name Sets Wildfly package name.
 # @param package_version Sets Wildfly package version.
@@ -105,12 +106,21 @@ class wildfly(
   Optional[String] $package_version                           = undef,
   Optional[String] $java_opts                                 = undef,
   Optional[String] $jboss_opts                                = undef,
+  Optional[String] $overlay_class                             = undef,
 ) {
 
   contain wildfly::prepare
   contain wildfly::install
   contain wildfly::setup
   contain wildfly::service
+
+  if $overlay_class {
+    contain $overlay_class
+
+    Class['wildfly::install']
+      -> Class[$overlay_class]
+        -> Class['wildfly::setup']
+  }
 
   if $external_facts {
     include wildfly::external_facts

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,4 +16,21 @@ describe 'wildfly' do
     it { is_expected.to contain_class('wildfly::setup').that_comes_before('Class[wildfly::service]') }
     it { is_expected.to contain_class('wildfly::service') }
   end
+
+  context 'with overlay_class' do
+    let(:facts) do
+      { :operatingsystem => 'CentOS',
+        :kernel => 'Linux',
+        :osfamily => 'RedHat',
+        :operatingsystemmajrelease => '7',
+        :initsystem => 'systemd' }
+    end
+
+    let(:pre_condition) { "class profile::jboss::overlay { notify { 'hello :D': } }" }
+
+    let(:params) { { overlay_class: 'profile::jboss::overlay' } }
+
+    it { is_expected.to contain_class('profile::jboss::overlay').that_requires('Class[wildfly::install]') }
+    it { is_expected.to contain_class('profile::jboss::overlay').that_comes_before('Class[wildfly::setup]') }
+  end
 end


### PR DESCRIPTION
This way we can, for example, use this parameter to provide a class that extracts a package into a jboss installation (like apiman and keycloak), or provides custom configuration files (like a custom host-slave.xml)