### PR TITLE
[Puppet 3] Add parameter `overlay_class` to apply a class between `wildfly::install` and `wildfly::setup` classes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,12 +45,21 @@ class wildfly(
   $shutdown_wait                = $wildfly::params::shutdown_wait,
   $secret_value                 = $wildfly::params::secret_value,
   $remote_username              = $wildfly::params::remote_username,
+  $overlay_class                = undef,
 ) inherits wildfly::params {
 
   include wildfly::prepare
   include wildfly::install
   include wildfly::setup
   include wildfly::service
+
+  if $overlay_class {
+    contain $overlay_class
+
+    Class['wildfly::install'] ->
+      Class[$overlay_class] ->
+        Class['wildfly::setup']
+  }
 
   Class['wildfly::prepare'] ->
     Class['wildfly::install'] ->

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -17,4 +17,22 @@ describe 'wildfly' do
     it { is_expected.to contain_class('wildfly::setup').that_comes_before('Class[wildfly::service]') }
     it { is_expected.to contain_class('wildfly::service') }
   end
+
+  context 'with overlay_class' do
+    let(:facts) do
+      { :operatingsystem => 'CentOS',
+        :kernel => 'Linux',
+        :osfamily => 'RedHat',
+        :operatingsystemmajrelease => '7',
+        :initsystem => 'systemd' }
+    end
+
+    let(:pre_condition) { "class profile::jboss::overlay { notify { 'hello :D': } }" }
+
+    let(:params) { { overlay_class: 'profile::jboss::overlay' } }
+
+    it { is_expected.to contain_class('profile::jboss::overlay').that_requires('Class[wildfly::install]') }
+    it { is_expected.to contain_class('profile::jboss::overlay').that_comes_before('Class[wildfly::setup]') }
+  end
+
 end


### PR DESCRIPTION
This way we can, for example, use this parameter to provide a class that extracts a package into a jboss installation (like apiman and keycloak), or provides custom configuration files (like a custom host-slave.xml). Compatible with Puppet 3