### PR TITLE
Use exec to call standalone.sh / domain.sh

### DIFF
--- a/files/launch.sh
+++ b/files/launch.sh
@@ -5,7 +5,7 @@ if [ "x$WILDFLY_HOME" = "x" ]; then
 fi
 
 if [[ "$1" == "domain" ]]; then
-    $WILDFLY_HOME/bin/domain.sh -c $2
+    exec $WILDFLY_HOME/bin/domain.sh -c $2
 else
-    $WILDFLY_HOME/bin/standalone.sh -c $2
+    exec $WILDFLY_HOME/bin/standalone.sh -c $2
 fi


### PR DESCRIPTION
In some cases, it is more usefull to rely on the configured shebang to
parse the configuration and execute the script. This is true when you
want to use $( evaluated expressions ) in java arguments.

One example could to to load the logging manager early in the wildfly
startup process since a javaagent might require it (jmx_explorer
really):

Example use case:

```puppet
$java_opts = [
  '-Xbootclasspath/p:$( echo ${JBOSS_HOME}/modules/system/layers/base/org/jboss/logmanager/main/jboss-logmanager-*.jar | head -n1 )',
  '-Djboss.modules.system.pkgs=org.jboss.byteman,org.jboss.logmanager',
  '-Djava.util.logging.manager=org.jboss.logmanager.LogManager',
].join(' ')
```