### PR TITLE
Enabled local file or puppet:// source as a install_source for the tar.gz file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,7 +51,7 @@
 # @param version Sets the Wildfly version managed in order to handle small differences among versions.
 class wildfly(
   Pattern[/^(\d{1,}\.\d{1,}(\.\d{1,})?$)/] $version           = '9.0.2',
-  Variant[Stdlib::Httpurl, Stdlib::Httpsurl] $install_source  = 'http://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final.tar.gz',
+  Variant[Pattern[/^file:\/\//], Pattern[/^puppet:\/\//], Stdlib::Httpsurl, Stdlib::Httpurl] $install_source = 'http://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final.tar.gz',
   Wildfly::Distribution $distribution                         = 'wildfly',
   Enum['sysvinit', 'systemd', 'upstart'] $init_system         = $facts['initsystem'],
   Wildfly::Mode $mode                                         = 'standalone',


### PR DESCRIPTION
Changes passed spec and acceptance tests.  Enable alternative install source locations besides http/https sources.