### PR TITLE
Allow `$` in treetop parsed strings.

### DIFF
--- a/lib/puppet_x/wildfly/jboss_cli.treetop
+++ b/lib/puppet_x/wildfly/jboss_cli.treetop
@@ -51,7 +51,7 @@ grammar JBossCLI
   end
 
   rule identifier
-    ([a-zA-Z0-9_\.\-\$]+ / '"' [a-zA-Z0-9_\.\-:/]+ '"')
+    ([a-zA-Z0-9_\.\-@\$]+ / '"' [a-zA-Z0-9_\.\-:/]+ '"')
   end
 
 end

--- a/lib/puppet_x/wildfly/jboss_cli.treetop
+++ b/lib/puppet_x/wildfly/jboss_cli.treetop
@@ -51,7 +51,7 @@ grammar JBossCLI
   end
 
   rule identifier
-    ([a-zA-Z0-9_\.\-]+ / '"' [a-zA-Z0-9_\.\-:/]+ '"')
+    ([a-zA-Z0-9_\.\-\$]+ / '"' [a-zA-Z0-9_\.\-:/]+ '"')
   end
 
 end


### PR DESCRIPTION
I'm in the process of upgrading from Puppet 3 to 4 and using this as an opportunity to upgrade to the latest wildfly module as well.

I had some parsing problems with Treetop, and the only ones I couldn't fix on our side were strings that had `$` in them.  I tried quoting them, escaping them everything I could think of but couldn't get it to pass Treetop's validation.

This PR allows dollar signs.  I'd love to get this accepted... this is the only real reason we'll have to run our fork.

The strings I had issue with are:
`
/subsystem=logging/logger=com.company.common.services.DefaultCompanyPoolExecutor$UserBasedCallable:dummy
/subsystem=logging/logger=com.company.common.services.DefaultCompanyThreadPoolExecutor$UserBasedRunnable:dummy
`

I tried this all the way up to master of the Puppet module.  If I'm missing something and need to escape this differently or in a way I haven't though of, please let me know.