### PR TITLE
Display `parser.failure_reason` when there's a failure.

### DIFF
--- a/lib/puppet_x/wildfly/cli_command.rb
+++ b/lib/puppet_x/wildfly/cli_command.rb
@@ -8,7 +8,7 @@ module PuppetX
         parser = JBossCLIParser.new
         @syntax_node = parser.parse(command)
 
-        raise "Invalid command syntax. Could not parse: #{command}" if @syntax_node.nil?
+        raise "Invalid command syntax. Could not parse: #{command}\nFailure reason: #{parser.failure_reason}" if @syntax_node.nil?
       end
 
       def address


### PR DESCRIPTION
This is closely tied to PR #241 but I wanted to submit it separately incase you didn't want it... It's definitely optional, but nice to have.

While debugging the Treetop parse errors we were having, this was very helpful.  Doesn't generate anymore logging  until there is an exception raised.