### PR TITLE
Use of hard-coded passwords is a bad practice 

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,6 @@
+:hierarchy:
+  - common
+:backends:
+  - yaml
+:yaml:
+:datadir: 'hieradata'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,0 +1,2 @@
+---
+wildfly_pwd: 'wildfly'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,7 +55,7 @@ class wildfly::params {
 
   $users_mgmt = {
     'wildfly' => {
-      password => 'wildfly',
+      password => hiera('wildfly_pwd'),
     },
   }
 


### PR DESCRIPTION
I am a security researcher, who is looking for security smells in Puppet scripts. 
I noticed two instances of hard-coded passwords, which are against the best practices 
recommended by Common Weakness Enumeration (CWE) [https://cwe.mitre.org/data/definitions/259.html] and also by other security practitioners.
I have added hiera support to mitigate this smell. Feedback is welcome. 

Here is where I noticed hard-coded passwords: https://github.com/biemond/biemond-wildfly/blob/v0.5.x/manifests/params.pp