### PR TITLE
add custom_config parameter to manage systemd EnvironmentFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
     * [Logging](#logging)
     * [Modcluster](#modcluster)
     * [JGroups](#jgroups)
+    * [Systemd Custom Config](#systemd-custom-config)
 6. [Limitations - OS compatibility, etc.](#limitations)
 7. [Development - Guide for contributing to the module](#development)
 8. [Documentation](#documentation)
@@ -825,6 +826,16 @@ wildfly::jgroups::stack::tcpping { 'TCPPING':
   initial_hosts       => '172.28.128.10[7600],17228.128.20[7600]',
   num_initial_members => 2
 }
+```
+
+### Systemd Custom Config
+
+To add additional variables to the systemd EnvironmentFile by hiera:
+```puppet
+wildfly::custom_config:
+  - "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/sap/jco/sap_jco_3.0.16_64:/opt/oracle/instantclient_11_2/lib"
+  - "NLS_LANG=GERMAN_GERMANY.WE8ISO8859P15"
+  - "LANG=de_DE@euro"
 ```
 
 ## Limitations

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,6 +99,7 @@ class wildfly(
   Optional[Stdlib::Unixpath] $service_file                    = undef,
   Optional[String] $systemd_template                          = undef,
   Optional[String] $service_name                              = undef,
+  Optional[Tuple] $custom_config                              = undef,
   Optional[String] $custom_init                               = undef,
   Optional[Integer] $uid                                      = undef,
   Optional[Integer] $gid                                      = undef,

--- a/templates/wildfly.systemd.conf.epp
+++ b/templates/wildfly.systemd.conf.epp
@@ -11,3 +11,8 @@ WILDFLY_HOME="<%= $wildfly::dirname %>"
 
 # Location of JDK
 JAVA_HOME=<%= $wildfly::java_home %>
+
+# Custom Config
+<% $wildfly::custom_config.each |$value| { -%>
+<%= $value %>
+<% } -%>


### PR DESCRIPTION
To inject some variables to the Systemd EnvironmentFile. 

For example: 
```
# Custom Config
JBOSS_MODULEPATH="$JBOSS_HOME/modules:/opt/wildfly_modules"
LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/sap/jco/sap_jco_3.0.16_64:/opt/oracle/instantclient_11_2/lib
NLS_LANG=GERMAN_GERMANY.WE8ISO8859P15
LANG=de_DE@euro
LC_ALL=de_DE.iso885915@euro
```