### PR TITLE
add possiblity to not reload service when change conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,7 @@
 # @param service_enable Sets Wildfly's service 'enable'.
 # @param service_file Sets a file to be used for service management.
 # @param service_name Sets Wildfly's service 'name'.
+# @param service_manage Reload Wildfly's service when changed config.
 # @param shutdown_wait Sets the time to wait for the process to be shutdown - sysvinit scripts only.
 # @param startup_wait Sets the time to wait for the process to be up - sysvinit scripts only.
 # @param systemd_template Sets a custom systemd template.
@@ -99,6 +100,7 @@ class wildfly(
   Optional[Stdlib::Unixpath] $service_file                    = undef,
   Optional[String] $systemd_template                          = undef,
   Optional[String] $service_name                              = undef,
+  Optional[Boolean] $service_manage                           = true,
   Optional[String] $custom_init                               = undef,
   Optional[Integer] $uid                                      = undef,
   Optional[Integer] $gid                                      = undef,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,6 +8,7 @@ class wildfly::service {
   $conf_file = pick($wildfly::conf_file, $config['conf_file'])
   $conf_template = pick($wildfly::conf_template, $config['conf_template'])
   $service_name = pick($wildfly::service_name, $config['service_name'])
+  $service_manage   = pick($wildfly::service_manage, $config['service_manage'])
   $service_file = pick($wildfly::service_file, $config['service_file'])
   $systemd_template = pick($wildfly::systemd_template, $config['systemd_template'], 'wildfly/wildfly.sysvinit.service')
 
@@ -26,12 +27,20 @@ class wildfly::service {
 
   }
 
-  file { $conf_file:
-    ensure  => present,
-    content => epp($conf_template),
+  if $service_manage {
+    file { $conf_file:
+      ensure  => present,
+      content => epp($conf_template),
+      notify  => Service['wildfly'],
+    }
+  } else {
+    file { $conf_file:
+      ensure  => present,
+      content => epp($conf_template),
+    }
   }
 
-  ~> service { 'wildfly':
+  service { 'wildfly':
     ensure     => $wildfly::service_ensure,
     name       => $service_name,
     enable     => $wildfly::service_enable,


### PR DESCRIPTION
Introduce service_manage to not reload wildfly service when conf has changed. 