### PR TITLE
Add `undeploy_first` parameter to `wildfly_deployment`

### DIFF
--- a/lib/puppet/provider/wildfly_deployment/http_api.rb
+++ b/lib/puppet/provider/wildfly_deployment/http_api.rb
@@ -24,7 +24,12 @@ Puppet::Type.type(:wildfly_deployment).provide :http_api, :parent => Puppet::Pro
 
   def content=(value)
     debug "Updating deploy #{@resource[:name]} with content from #{@resource[:source]}"
-    cli.update_deploy(@resource[:name], @resource[:source], @resource[:server_group], @resource[:operation_headers])
+    if @resource[:undeploy_first]
+      destroy
+      create
+    else
+      cli.update_deploy(@resource[:name], @resource[:source], @resource[:server_group], @resource[:operation_headers])
+    end
   end
 
   def server_group_address

--- a/lib/puppet/type/wildfly_deployment.rb
+++ b/lib/puppet/type/wildfly_deployment.rb
@@ -1,4 +1,5 @@
 require 'digest'
+require 'puppet/parameter/boolean'
 
 Puppet::Type.newtype(:wildfly_deployment) do
   desc 'Manages JBoss deployment'
@@ -39,7 +40,7 @@ Puppet::Type.newtype(:wildfly_deployment) do
   end
 
   newparam(:timeout) do
-    desc 'Operation timeout. Defaults to 120'
+    desc 'Operation timeout. Defaults to 300'
     defaultto 300
 
     munge(&:to_i)
@@ -52,6 +53,11 @@ Puppet::Type.newtype(:wildfly_deployment) do
     validate do |value|
       raise("#{value} is not a Hash") unless value.is_a?(Hash)
     end
+  end
+
+  newparam(:undeploy_first, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc 'Whether to perform an undeploy before redeploying'
+    defaultto :false # rubocop:disable Lint/BooleanSymbol
   end
 
   newproperty(:content) do

--- a/manifests/deployment.pp
+++ b/manifests/deployment.pp
@@ -11,16 +11,18 @@
 # @param password The password for Wildfly's management user.
 # @param host The IP address or FQDN of the JBoss Management service.
 # @param port The port of the JBoss Management service.
+# @param undeploy_first Instead of 'updating' a deployment, should the existing deployment be undeployed and then redeployed?
 define wildfly::deployment(
   Variant[Pattern[/^file:\/\//], Pattern[/^puppet:\/\//], Stdlib::Httpsurl, Stdlib::Httpurl] $source,
-  Enum[present, absent] $ensure  = present,
-  Optional[Integer] $timeout     = undef,
-  Optional[String] $server_group = undef,
-  $operation_headers             = {},
-  String $username               = $wildfly::mgmt_user['username'],
-  String $password               = $wildfly::mgmt_user['password'],
-  String $host                   = $wildfly::properties['jboss.bind.address.management'],
-  String $port                   = $wildfly::properties['jboss.management.http.port'],
+  Enum[present, absent] $ensure     = present,
+  Optional[Integer] $timeout        = undef,
+  Optional[String] $server_group    = undef,
+  $operation_headers                = {},
+  String $username                  = $wildfly::mgmt_user['username'],
+  String $password                  = $wildfly::mgmt_user['password'],
+  String $host                      = $wildfly::properties['jboss.bind.address.management'],
+  String $port                      = $wildfly::properties['jboss.management.http.port'],
+  Optional[Boolean] $undeploy_first = undef,
 ) {
   $file_name = basename($source)
 
@@ -42,6 +44,7 @@ define wildfly::deployment(
     timeout           => $timeout,
     source            => "${wildfly::deploy_cache_dir}/${file_name}",
     operation_headers => $operation_headers,
+    undeploy_first    => $undeploy_first,
     require           => [Service['wildfly'], File["${wildfly::deploy_cache_dir}/${file_name}"]],
   }
 

--- a/spec/types/wildfly_deployment_spec.rb
+++ b/spec/types/wildfly_deployment_spec.rb
@@ -8,10 +8,10 @@ describe Puppet::Type.type(:wildfly_deployment) do
   end
 
   it 'has expected parameters' do
-    expect(deployment.parameters).to include(:name, :source, :server_group, :username, :password, :host, :port, :timeout, :operation_headers)
+    expect(deployment.parameters).to include(:name, :source, :server_group, :username, :password, :host, :port, :timeout, :operation_headers, :undeploy_first)
   end
 
-  describe 'when testing wheter content checksum is in sync' do
+  describe 'when testing whether content checksum is in sync' do
     let(:resource) { described_class.new(:name => 'app.ear') }
 
     it 'is if deployed content SHA1 checksum matches source checksum' do

--- a/spec/unit/puppet/provider/wildfly_deployment/http_api_spec.rb
+++ b/spec/unit/puppet/provider/wildfly_deployment/http_api_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:wildfly_deployment).provider(:http_api)
+
+describe provider_class do
+  let :resource do
+    Puppet::Type.type(:wildfly_deployment).new(
+      :name              => 'test.ear',
+      :source            => '/tmp/test.ear',
+      :operation_headers => {},
+      :provider          => :http_api)
+  end
+
+  let :provider do
+    resource.provider
+  end
+
+  describe 'content=' do
+    describe 'undeploy_first' do
+      context 'by default' do
+        it 'undeploy_first is false' do
+          expect(resource[:undeploy_first]).to be(false)
+        end
+        it 'calls `update_deploy`' do
+          expect(provider).not_to receive(:destroy)
+          expect(provider).not_to receive(:create)
+
+          cli = double
+          allow(provider).to receive(:cli).and_return(cli)
+
+          expect(provider.cli).to receive(:update_deploy).with('test.ear', '/tmp/test.ear', nil, {})
+          provider.content = 'unused'
+        end
+      end
+      context 'when undeploy_first => true' do
+        it 'calls `destroy` followed by `create`' do
+          resource[:undeploy_first] = true
+          expect(provider).to receive(:destroy).ordered
+          expect(provider).to receive(:create).ordered
+          provider.content = 'unused'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Instead of using `cli.update_deploy`, when setting this parameter to
`true`, the deployment is undeployed, before being redeployed.