### PR TITLE
Always define module_dir variable

### DIFF
--- a/manifests/config/module.pp
+++ b/manifests/config/module.pp
@@ -19,6 +19,8 @@ define wildfly::config::module(
 
   if $system {
     $module_dir = 'system/layers/base'
+  } else {
+    $module_dir = ''
   }
 
   File {


### PR DESCRIPTION
Restore the definition of a blank module_dir that was removed in 33a83514 in order to prevent Puppet warnings about undeclared variables.

After attempting to use this module in a Puppet 4 environment, Puppet issues warnings about the missing variable such as:

`==> fbstandalone: Warning: Unknown variable: 'module_dir'. at /tmp/vagrant-puppet/modules-6f8cfc5da5ac652a8bb050dde61d3361/wildfly/manifests/config/module.pp:29:46
==> fbstandalone: Warning: Unknown variable: 'module_dir'. at /tmp/vagrant-puppet/modules-6f8cfc5da5ac652a8bb050dde61d3361/wildfly/manifests/config/module.pp:29:46
`