### PR TITLE
Add new `refreshonly` parameter to wildfly_cli and wrapper

### DIFF
--- a/lib/puppet/provider/wildfly_cli/http_api.rb
+++ b/lib/puppet/provider/wildfly_cli/http_api.rb
@@ -3,9 +3,9 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'wildfly'))
 Puppet::Type.type(:wildfly_cli).provide :http_api, :parent => Puppet::Provider::Wildfly do
   desc 'Uses JBoss HTTP API to execute a JBoss-CLI command'
 
-  def exec(command)
-    debug "Running: #{command}"
-    cli.exec(command)
+  def exec_command
+    debug "Running: #{@resource[:command]}"
+    cli.exec(@resource[:command])
   end
 
   def should_execute?

--- a/lib/puppet/type/wildfly_cli.rb
+++ b/lib/puppet/type/wildfly_cli.rb
@@ -1,3 +1,5 @@
+require 'puppet/parameter/boolean'
+
 Puppet::Type.newtype(:wildfly_cli) do
   desc 'Executes JBoss-CLI commmands'
 
@@ -13,6 +15,11 @@ Puppet::Type.newtype(:wildfly_cli) do
 
   newparam(:onlyif) do
     desc 'If this parameter is set, then CLI command will only run if this command returns false'
+  end
+
+  newparam(:refreshonly, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc 'If this parameter is set, then CLI command will only run if the resource was notified'
+    defaultto false
   end
 
   newparam(:username) do
@@ -43,7 +50,14 @@ Puppet::Type.newtype(:wildfly_cli) do
     end
 
     def sync
-      provider.exec(@resource[:command])
+      provider.exec_command unless refreshonly?
+    end
+  end
+
+  def refresh
+    if refreshonly? and provider.should_execute?
+      Puppet.debug 'Executing wildfly_cli because resource received a refresh signal and refreshonly is true'
+      provider.exec_command
     end
   end
 end

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -14,6 +14,7 @@ define wildfly::cli(
   String $command          = $title,
   Optional[String] $unless = undef,
   Optional[String] $onlyif = undef,
+  Optional[Boolean] $refreshonly = undef,
   String $username         = $wildfly::mgmt_user['username'],
   String $password         = $wildfly::mgmt_user['password'],
   String $host             = $wildfly::properties['jboss.bind.address.management'],
@@ -21,14 +22,15 @@ define wildfly::cli(
 ) {
 
   wildfly_cli { $title:
-    command  => $command,
-    username => $username,
-    password => $password,
-    host     => $host,
-    port     => $port,
-    unless   => $unless,
-    onlyif   => $onlyif,
-    require  => Service['wildfly'],
+    command     => $command,
+    username    => $username,
+    password    => $password,
+    host        => $host,
+    port        => $port,
+    unless      => $unless,
+    onlyif      => $onlyif,
+    refreshonly => $refreshonly,
+    require     => Service['wildfly'],
   }
 
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
-require 'rspec-puppet'
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 require 'coveralls'
@@ -27,7 +30,6 @@ support_path = File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec/su
 Dir[support_path].each { |f| require f }
 
 RSpec.configure do |c|
-  c.mock_with :rspec
   c.config = '/doesnotexist'
   c.module_path  = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures/modules'))
   c.manifest_dir = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures/manifests'))

--- a/spec/unit/puppet/type/wildfly_cli_spec.rb
+++ b/spec/unit/puppet/type/wildfly_cli_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'puppet/type'
+require 'puppet/type/wildfly_cli'
+
+describe Puppet::Type.type(:wildfly_cli) do
+  let(:resource) { Puppet::Type.type(:wildfly_cli).new(name: 'Example Command') }
+  let(:provider) { Puppet::Provider.new(resource) }
+
+  before :each do
+    resource.provider = provider
+  end
+
+  it 'is an instance of Puppet::Type::Wildfly_cli' do
+    expect(resource).to be_an_instance_of Puppet::Type::Wildfly_cli
+  end
+
+  context 'when refreshed' do
+    context 'when `refreshonly` parameter is `true`' do
+      before :each do
+        resource[:refreshonly] = true
+      end
+      context 'and `should_execute?` returns true' do
+        it 'runs command' do
+          expect(provider).to receive(:should_execute?).and_return(true)
+          expect(provider).to receive(:exec_command)
+
+          resource.refresh
+        end
+      end
+      context 'when `should_execute?` returns false' do
+        it 'doesn\'t run command' do
+          expect(provider).to receive(:should_execute?).and_return(false)
+          expect(provider).not_to receive(:exec_command)
+
+          resource.refresh
+        end
+      end
+    end
+    context 'when `refreshonly` parameter is `false`' do
+      it 'doesn\'t run command' do
+        resource[:refreshonly] = false
+        expect(provider).not_to receive(:exec_command)
+
+        resource.refresh
+      end
+    end
+  end
+end


### PR DESCRIPTION
The current type has `unless` and `onlyif` parameters, but I need to run wildfly cli commands when other puppet resources get updated.