### PR TITLE
module.pp: do not fail on mkdir

### DIFF
--- a/manifests/config/module.pp
+++ b/manifests/config/module.pp
@@ -32,7 +32,6 @@ define wildfly::config::module(
     path    => ['/bin','/usr/bin', '/sbin'],
     command => "mkdir -p ${dir_path}",
     unless  => "test -d ${dir_path}",
-    user    => $wildfly::user,
     before  => [File[$dir_path]],
   }
 


### PR DESCRIPTION
When installed via RPM or similar, the `modules` directory is owned by root.
Therefore, `mkdir -p` fails when executed as `$wildfly::user`.