### PR TITLE
Allow custom settings for https-listener while using undertow::https type

### DIFF
--- a/manifests/undertow/https.pp
+++ b/manifests/undertow/https.pp
@@ -11,25 +11,23 @@ define wildfly::undertow::https(
   $target_profile = undef,
   $enabled_protocols = undef,
   $enabled_cipher_suites = undef,
-  $record_request_start_time = undef) {
+  $https_listener_content = undef) {
 
   if versioncmp($wildfly::version,'9.0.0') >= 0 {
     # Wildfly 9 and higher -> we need to set enable parameter
-    $listener_content = {
-      'socket-binding'            => $socket_binding,
-      'security-realm'            => 'TLSRealm',
-      'enabled-protocols'         => $enabled_protocols,
-      'enabled-cipher-suites'     => $enabled_cipher_suites,
-      'record-request-start-time' => $record_request_start_time,
-      'enabled'                   => true,
+    $listener_content = $https_listener_content + {
+      'socket-binding'        => $socket_binding,
+      'security-realm'        => 'TLSRealm',
+      'enabled-protocols'     => $enabled_protocols,
+      'enabled-cipher-suites' => $enabled_cipher_suites,
+      'enabled'               => true,
     }
   } else {
-    $listener_content = {
-      'socket-binding'            => $socket_binding,
-      'security-realm'            => 'TLSRealm',
-      'enabled-protocols'         => $enabled_protocols,
-      'enabled-cipher-suites'     => $enabled_cipher_suites,
-      'record-request-start-time' => $record_request_start_time,
+    $listener_content = $https_listener_content + {
+      'socket-binding'        => $socket_binding,
+      'security-realm'        => 'TLSRealm',
+      'enabled-protocols'     => $enabled_protocols,
+      'enabled-cipher-suites' => $enabled_cipher_suites,
     }
   }
 

--- a/manifests/undertow/https.pp
+++ b/manifests/undertow/https.pp
@@ -10,23 +10,26 @@ define wildfly::undertow::https(
   $key_password = undef,
   $target_profile = undef,
   $enabled_protocols = undef,
-  $enabled_cipher_suites = undef) {
+  $enabled_cipher_suites = undef,
+  $record_request_start_time = undef) {
 
   if versioncmp($wildfly::version,'9.0.0') >= 0 {
     # Wildfly 9 and higher -> we need to set enable parameter
     $listener_content = {
-      'socket-binding'        => $socket_binding,
-      'security-realm'        => 'TLSRealm',
-      'enabled-protocols'     => $enabled_protocols,
-      'enabled-cipher-suites' => $enabled_cipher_suites,
-      'enabled'               => true,
+      'socket-binding'            => $socket_binding,
+      'security-realm'            => 'TLSRealm',
+      'enabled-protocols'         => $enabled_protocols,
+      'enabled-cipher-suites'     => $enabled_cipher_suites,
+      'record-request-start-time' => $record_request_start_time,
+      'enabled'                   => true,
     }
   } else {
     $listener_content = {
-      'socket-binding'        => $socket_binding,
-      'security-realm'        => 'TLSRealm',
-      'enabled-protocols'     => $enabled_protocols,
-      'enabled-cipher-suites' => $enabled_cipher_suites,
+      'socket-binding'            => $socket_binding,
+      'security-realm'            => 'TLSRealm',
+      'enabled-protocols'         => $enabled_protocols,
+      'enabled-cipher-suites'     => $enabled_cipher_suites,
+      'record-request-start-time' => $record_request_start_time,
     }
   }
 


### PR DESCRIPTION
Currently, it is not possible to use both the undertow::https type and configure the https-listener because this type already uses this resource.
With this merge, the parameter https_listener_content is added where a custom configuration can be made. This configuration may be overwritten, e.g. the security-realm is 'TLSRealm' and cannot be changed with this new parameter.