### PR TITLE
Fix packages URLs from maven.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ Source supports these protocols: `http://`, `ftp://`, `puppet://`, `file://`
 
 ```puppet
 wildfly::deployment { 'hawtio.war':
- source => 'http://central.maven.org/maven2/io/hawt/hawtio-web/1.4.48/hawtio-web-1.4.48.war',
+ source => 'https://repo1.maven.org/maven2/io/hawt/hawtio-web/1.4.66/hawtio-web-1.4.66.war',
 }
 ```
 
@@ -551,7 +551,7 @@ wildfly::deployment { 'hawtio.war':
 
 ```puppet
 wildfly::deployment { 'hawtio.war':
- source       => 'http://central.maven.org/maven2/io/hawt/hawtio-web/1.4.48/hawtio-web-1.4.48.war',
+ source       => 'https://repo1.maven.org/maven2/io/hawt/hawtio-web/1.4.66/hawtio-web-1.4.66.war',
  server_group => 'main-server-group',
 }
 ```
@@ -609,7 +609,7 @@ Install a JAR module from a remote file system, puppet file server or local file
 
 ```puppet
 wildfly::config::module { 'org.postgresql':
-  source       => 'http://central.maven.org/maven2/org/postgresql/postgresql/9.3-1103-jdbc4/postgresql-9.3-1103-jdbc4.jar',
+  source       => 'https://repo1.maven.org/maven2/org/postgresql/postgresql/9.3-1103-jdbc4/postgresql-9.3-1103-jdbc4.jar',
   dependencies => ['javax.api', 'javax.transaction.api']
 }
 ```
@@ -654,7 +654,7 @@ Alternatively, you can install a JDBC driver and module using deployment if your
 
 ```puppet
 wildfly::deployment { 'postgresql-9.3-1103-jdbc4.jar':
-  source => 'http://central.maven.org/maven2/org/postgresql/postgresql/9.3-1103-jdbc4/postgresql-9.3-1103-jdbc4.jar'
+  source => 'https://repo1.maven.org/maven2/org/postgresql/postgresql/9.3-1103-jdbc4/postgresql-9.3-1103-jdbc4.jar'
 }
 ->
 wildfly::datasources::datasource { 'DemoDS':
@@ -672,7 +672,7 @@ A postgresql normal & XA datasource example
 
 ```puppet
 wildfly::config::module { 'org.postgresql':
-  source       => 'http://central.maven.org/maven2/org/postgresql/postgresql/9.3-1103-jdbc4/postgresql-9.3-1103-jdbc4.jar',
+  source       => 'https://repo1.maven.org/maven2/org/postgresql/postgresql/9.3-1103-jdbc4/postgresql-9.3-1103-jdbc4.jar',
   dependencies => ['javax.api', 'javax.transaction.api'],
   require      => Class['wildfly'],
 }

--- a/spec/acceptance/1_standalone_spec.rb
+++ b/spec/acceptance/1_standalone_spec.rb
@@ -13,7 +13,7 @@ describe "Standalone mode with #{test_data['distribution']}:#{test_data['version
           }
 
           wildfly::config::module { 'org.postgresql':
-            source       => 'http://central.maven.org/maven2/org/postgresql/postgresql/9.3-1103-jdbc4/postgresql-9.3-1103-jdbc4.jar',
+            source       => 'https://repo1.maven.org/maven2/org/postgresql/postgresql/9.3-1103-jdbc4/postgresql-9.3-1103-jdbc4.jar',
             dependencies => ['javax.api', 'javax.transaction.api']
           }
           ->

--- a/spec/acceptance/2_deployment_spec.rb
+++ b/spec/acceptance/2_deployment_spec.rb
@@ -14,11 +14,11 @@ describe "Deployment on standalone mode with #{test_data['distribution']}:#{test
           }
 
           wildfly::deployment { 'hawtio.war':
-            source => 'http://central.maven.org/maven2/io/hawt/hawtio-web/1.4.66/hawtio-web-1.4.66.war'
+            source => 'https://repo1.maven.org/maven2/io/hawt/hawtio-web/1.4.66/hawtio-web-1.4.66.war'
           }
 
           wildfly::deployment { 'sample.war':
-            source => 'http://central.maven.org/maven2/org/codehaus/cargo/simple-war/1.6.2/simple-war-1.6.2.war'
+            source => 'https://repo1.maven.org/maven2/org/codehaus/cargo/simple-war/1.6.2/simple-war-1.6.2.war'
           }
       EOS
 

--- a/spec/acceptance/3_recursive_resource_spec.rb
+++ b/spec/acceptance/3_recursive_resource_spec.rb
@@ -13,7 +13,7 @@ describe "Standalone mode with complex/recursive resources and #{test_data['dist
           }
 
           wildfly::config::module { 'org.postgresql':
-            source       => 'http://central.maven.org/maven2/org/postgresql/postgresql/9.3-1103-jdbc4/postgresql-9.3-1103-jdbc4.jar',
+            source       => 'https://repo1.maven.org/maven2/org/postgresql/postgresql/9.3-1103-jdbc4/postgresql-9.3-1103-jdbc4.jar',
             dependencies => ['javax.api', 'javax.transaction.api'],
           }
           ->

--- a/spec/acceptance/4_domain_spec.rb
+++ b/spec/acceptance/4_domain_spec.rb
@@ -24,7 +24,7 @@ describe "Domain mode with #{test_data['distribution']}:#{test_data['version']}"
           }
 
           wildfly::deployment { 'hawtio.war':
-            source       => 'http://central.maven.org/maven2/io/hawt/hawtio-web/1.4.66/hawtio-web-1.4.66.war',
+            source       => 'https://repo1.maven.org/maven2/io/hawt/hawtio-web/1.4.66/hawtio-web-1.4.66.warhawtio-web-1.4.66.war',
             server_group => 'main-server-group',
           }
 

--- a/spec/acceptance/5_domain_spec_custom_server_group.rb
+++ b/spec/acceptance/5_domain_spec_custom_server_group.rb
@@ -20,7 +20,7 @@ describe "Domain mode with #{test_data['distribution']}:#{test_data['version']} 
           }
 
           wildfly::deployment { 'hawtio.war':
-            source       => 'http://central.maven.org/maven2/io/hawt/hawtio-web/1.4.66/hawtio-web-1.4.66.war',
+            source       => 'https://repo1.maven.org/maven2/io/hawt/hawtio-web/1.4.66/hawtio-web-1.4.66.war',
             server_group => 'app-server-group',
           }
 


### PR DESCRIPTION
http://central.maven.org is not working anymore; replacing with https://repo1.maven.org