### PR TITLE
Remove obsolete java parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,15 +19,13 @@
 # @param install_download_timeout Sets the timeout for installer download.
 # @param install_source Source of Wildfly tarball installer.
 # @param java_home Sets the `JAVA_HOME` for Wildfly.
-# @param java_opts Sets `JAVA_OPTS`, allowing to override several Java params, like `Xmx`, `Xms` and `MaxPermSize`,
+# @param java_opts Sets `JAVA_OPTS`, allowing to override several Java params, like `Xmx`, `Xms`,
 # @param java_xmx Sets Java's `-Xmx` parameter.
 # @param java_xms Sets Java's `-Xms` parameter.
-# @param java_maxpermsize Sets Java's `-XX:MaxPermSize` parameter.
-#   e.g. `-Xms64m -Xmx512m -XX:MaxPermSize=256m`.
 # @param jboss_opts Sets `JBOSS_OPTS`, allowing to override several JBoss properties. It only works with Wildfly 8.2+.
 # @param manage_user Whether this module should manage wildfly user and group.
 # @param mgmt_user Hash containing a Wildfly's management user to be used internally.
-# @param mgmt_create_keystore Enables or disables the creation of keystores for TLS enabled ManagementRealm.
+# @param mgmt_create_keystores Enables or disables the creation of keystores for TLS enabled ManagementRealm.
 # @param mgmt_keystore Path to a pre-defined keystore to be used for a TLS enabled ManagementRealm.
 # @param mgmt_keystore_alias The java keystore 'alias' to be used for a TLS enabled ManagementRealm.
 # @param mgmt_keystore_pass The java keystore password to be used for a TLS enabled ManagementRealm.
@@ -57,43 +55,46 @@
 # @param user User to own `JBOSS_HOME`. If `manage_user` is `true`, this user will be managed.
 # @param user_home User home directory. Defaults to '/home/wildfly'
 # @param version Sets the Wildfly version managed in order to handle small differences among versions.
-class wildfly(
-  Pattern[/^(\d{1,}\.\d{1,}(\.\d{1,})?$)/] $version           = '9.0.2',
-  Variant[Pattern[/^file:\/\//], Pattern[/^puppet:\/\//], Stdlib::Httpsurl, Stdlib::Httpurl] $install_source = "http://download.jboss.org/wildfly/${version}.Final/wildfly-${version}.Final.tar.gz",
-  Wildfly::Distribution $distribution                         = 'wildfly',
-  Enum['sysvinit', 'systemd', 'upstart'] $init_system         = $facts['initsystem'],
-  Wildfly::Mode $mode                                         = 'standalone',
-  Stdlib::Unixpath $dirname                                   = '/opt/wildfly',
-  Stdlib::Unixpath $java_home                                 = '/usr/java/default',
-  Stdlib::Unixpath $console_log                               = '/var/log/wildfly/console.log',
-  Stdlib::Unixpath $install_cache_dir                         = '/var/cache/wget',
-  Stdlib::Unixpath $deploy_cache_dir                          = '/opt',
-  Stdlib::Unixpath $mgmt_keystore                             = "${dirname}/${mode}/configuration/mgmt.jks",
-  Boolean $manage_user                                        = true,
-  String $user                                                = 'wildfly',
-  Stdlib::Unixpath $user_home                                 = '/home/wildfly',
-  String $group                                               = 'wildfly',
-  String $mode_template                                       = "wildfly/${mode}.conf",
-  String $mgmt_keystore_pass                                  = 'changeit',
-  String $mgmt_keystore_alias                                 = 'mgmt',
-  Wildfly::Config_file $config                                = 'standalone.xml',
-  Wildfly::Config_file $domain_config                         = 'domain.xml',
-  Wildfly::Config_file $host_config                           = 'host.xml',
-  String $java_xmx                                            = '512m',
-  String $java_xms                                            = '256m',
-  String $java_maxpermsize                                    = '128m',
-  String $package_ensure                                      = 'present',
-  Boolean $service_ensure                                     = true,
-  Boolean $service_enable                                     = true,
-  Boolean $remote_debug                                       = false,
-  Boolean $external_facts                                     = false,
-  Boolean $secure_mgmt_api                                    = false,
-  Boolean $mgmt_create_keystores                              = true,
-  Integer $remote_debug_port                                  = 8787,
-  Integer $startup_wait                                       = 30,
-  Integer $shutdown_wait                                      = 30,
-  Integer $install_download_timeout                           = 500,
-  Hash[Pattern[/^\w*(\.\w*-?\w*)*$/], String] $properties     = {
+class wildfly (
+  Pattern[/^(\d{1,}\.\d{1,}(\.\d{1,})?$)/]           $version                  = '9.0.2',
+  Variant[Pattern[/^file:\/\//],
+    Pattern[/^puppet:\/\//],
+    Stdlib::Httpsurl, Stdlib::Httpurl
+  ]                                                  $install_source           = "http://download.jboss.org/wildfly/${version}.Final/wildfly-${version}.Final.tar.gz",
+  Wildfly::Distribution                              $distribution             = 'wildfly',
+  Enum['sysvinit', 'systemd', 'upstart']             $init_system              = $facts['initsystem'],
+  Wildfly::Mode                                      $mode                     = 'standalone',
+  Stdlib::Unixpath                                   $dirname                  = '/opt/wildfly',
+  Stdlib::Unixpath                                   $java_home                = '/usr/java/default',
+  Stdlib::Unixpath                                   $console_log              = '/var/log/wildfly/console.log',
+  Stdlib::Unixpath                                   $install_cache_dir        = '/var/cache/wget',
+  Stdlib::Unixpath                                   $deploy_cache_dir         = '/opt',
+  Stdlib::Unixpath                                   $mgmt_keystore            = "${dirname}/${mode}/configuration/mgmt.jks",
+  Boolean                                            $manage_user              = true,
+  String                                             $user                     = 'wildfly',
+  Stdlib::Unixpath                                   $user_home                = '/home/wildfly',
+  String                                             $group                    = 'wildfly',
+  String                                             $mode_template            = "wildfly/${mode}.conf",
+  String                                             $mgmt_keystore_pass       = 'changeit',
+  String                                             $mgmt_keystore_alias      = 'mgmt',
+  Wildfly::Config_file                               $config                   = 'standalone.xml',
+  Wildfly::Config_file                               $domain_config            = 'domain.xml',
+  Wildfly::Config_file                               $host_config              = 'host.xml',
+  String                                             $java_xmx                 = '512m',
+  String                                             $java_xms                 = '256m',
+  String                                             $package_ensure           = 'present',
+  Boolean                                            $service_ensure           = true,
+  Boolean                                            $service_manage           = true,
+  Boolean                                            $service_enable           = true,
+  Boolean                                            $remote_debug             = false,
+  Boolean                                            $external_facts           = false,
+  Boolean                                            $secure_mgmt_api          = false,
+  Boolean                                            $mgmt_create_keystores    = true,
+  Integer                                            $remote_debug_port        = 8787,
+  Integer                                            $startup_wait             = 30,
+  Integer                                            $shutdown_wait            = 30,
+  Integer                                            $install_download_timeout = 500,
+  Hash[Pattern[/^\w*(\.\w*-?\w*)*$/], String]        $properties               = {
     'jboss.bind.address' => '0.0.0.0',
     'jboss.bind.address.management' => '127.0.0.1',
     'jboss.management.http.port' => '9990',
@@ -102,31 +103,28 @@ class wildfly(
     'jboss.https.port' => '8443',
     'jboss.ajp.port' => '8009',
   },
-  Struct[{username => String,
-          password => String}] $mgmt_user                     = {
+  Struct[{ username => String, password => String }] $mgmt_user                = {
     username => 'puppet',
     password => fqdn_rand_string(30),
   },
-  Optional[Stdlib::Unixpath] $conf_file                       = undef,
-  Optional[String] $conf_template                             = undef,
-  Optional[Stdlib::Unixpath] $service_file                    = undef,
-  Optional[String] $systemd_template                          = undef,
-  Optional[String] $service_name                              = undef,
-  Optional[Boolean] $service_manage                           = true,
-  Optional[String] $custom_init                               = undef,
-  Optional[Integer] $uid                                      = undef,
-  Optional[Integer] $gid                                      = undef,
-  Optional[String] $secret_value                              = undef,
-  Optional[String] $remote_username                           = undef,
-  Optional[String] $package_name                              = undef,
-  Optional[String] $package_version                           = undef,
-  Optional[String] $java_opts                                 = undef,
-  Optional[String] $jboss_opts                                = undef,
-  Optional[String] $overlay_class                             = undef,
-  Optional[Stdlib::Unixpath] $mgmt_ssl_cert                   = undef,
-  Optional[Stdlib::Unixpath] $mgmt_ssl_key                    = undef,
+  Optional[Stdlib::Unixpath]                         $conf_file                = undef,
+  Optional[String]                                   $conf_template            = undef,
+  Optional[Stdlib::Unixpath]                         $service_file             = undef,
+  Optional[String]                                   $systemd_template         = undef,
+  Optional[String]                                   $service_name             = undef,
+  Optional[String]                                   $custom_init              = undef,
+  Optional[Integer]                                  $uid                      = undef,
+  Optional[Integer]                                  $gid                      = undef,
+  Optional[String]                                   $secret_value             = undef,
+  Optional[String]                                   $remote_username          = undef,
+  Optional[String]                                   $package_name             = undef,
+  Optional[String]                                   $package_version          = undef,
+  Optional[String]                                   $java_opts                = undef,
+  Optional[String]                                   $jboss_opts               = undef,
+  Optional[String]                                   $overlay_class            = undef,
+  Optional[Stdlib::Unixpath]                         $mgmt_ssl_cert            = undef,
+  Optional[Stdlib::Unixpath]                         $mgmt_ssl_key             = undef,
 ) {
-
   contain wildfly::prepare
   contain wildfly::install
   contain wildfly::setup
@@ -136,15 +134,15 @@ class wildfly(
     contain $overlay_class
 
     Class['wildfly::install']
-      -> Class[$overlay_class]
-        -> Class['wildfly::setup']
+    -> Class[$overlay_class]
+    -> Class['wildfly::setup']
   }
 
   if $external_facts {
     contain wildfly::external_facts
 
     Class['wildfly::external_facts']
-      -> Class['wildfly::install']
+    -> Class['wildfly::install']
   }
 
   if $secure_mgmt_api {
@@ -152,7 +150,7 @@ class wildfly(
   }
 
   Class['wildfly::prepare']
-    -> Class['wildfly::install']
-      -> Class['wildfly::setup']
-        -> Class['wildfly::service']
+  -> Class['wildfly::install']
+  -> Class['wildfly::setup']
+  -> Class['wildfly::service']
 }

--- a/templates/domain.conf.epp
+++ b/templates/domain.conf.epp
@@ -42,7 +42,7 @@ fi
 # Specify options to pass to the Java VM.
 #
 if [ "x$JAVA_OPTS" = "x" ]; then
-    JAVA_OPTS="-Xms<%= $wildfly::java_xms %> -Xmx<%= $wildfly::java_xmx %> -XX:MaxPermSize=<%= $wildfly::java_maxpermsize %>"
+    JAVA_OPTS="-Xms<%= $wildfly::java_xms %> -Xmx<%= $wildfly::java_xmx %>"
     JAVA_OPTS="$JAVA_OPTS <%= $wildfly::java_opts %>"
 else
     echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"

--- a/templates/standalone.conf.epp
+++ b/templates/standalone.conf.epp
@@ -47,7 +47,7 @@ fi
 # Specify options to pass to the Java VM.
 #
 if [ "x$JAVA_OPTS" = "x" ]; then
-   JAVA_OPTS="-Xms<%= $wildfly::java_xms %> -Xmx<%= $wildfly::java_xmx %> -XX:MaxPermSize=<%= $wildfly::java_maxpermsize %>"
+   JAVA_OPTS="-Xms<%= $wildfly::java_xms %> -Xmx<%= $wildfly::java_xmx %>"
    JAVA_OPTS="$JAVA_OPTS <%= $wildfly::java_opts %>"
 else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"


### PR DESCRIPTION
This remove obsolete java parameter: MaxPermSize
Which is deprecated from java8 and removed in java17
Also cleanup structure in init.pp