### PR TITLE
Update bundle install commands in README test setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,7 +936,8 @@ This module uses puppet-lint, rubocop, rspec-puppet, beaker and travis-ci. We ho
 
 ```shell
 gem install bundler --no-rdoc --no-ri
-bundle install --without development
+bundle config set --local without 'development'
+bundle install
 
 bundle exec rake syntax
 bundle exec rake lint


### PR DESCRIPTION
`--without development` flag for `bundle install` is deprecated:

```Shell
bundle install --without development
[DEPRECATED] The `--without` flag is deprecated because it relies on being remembered
across bundler invocations, which bundler will no longer do in future versions.
Instead please use `bundle config set --local without 'development'`, and stop using this flag
```

This change adds the `config set` step and a plain `bundle install` in the README