### PR TITLE
Use rvm and Ruby 2.7 in README test setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,12 +772,12 @@ This feature is currently implemented for standalone mode only.  The default htt
 This will generate and use a basic self signed certificate for the Management interface.  Requires the puppetlabs/java_ks module:
 
 ```puppet
-class { 'wildfly': 
+class { 'wildfly':
 	secure_mgmt_api => true,
 }
 ```
 
-#### Providing your own certificate 
+#### Providing your own certificate
 The module will create the approprate keystores, truststores, and configuration if given paths to the private key and certificate.  Use your favorite method to ensure the key and certificate exist on the endpoint.  Requires the puppetlabs/java_ks module:
 
 ```puppet

--- a/README.md
+++ b/README.md
@@ -958,7 +958,7 @@ ruby 2.7.x (20XX-YY-ZZ revision &lt;Hash&gt;) [x86_64-linux]
 ```
 
 ```shell
-gem install bundler --no-rdoc --no-ri
+gem install bundler --no-document
 bundle config set --local without 'development'
 bundle install
 

--- a/README.md
+++ b/README.md
@@ -934,6 +934,15 @@ JBoss EAP only works with RHEL-based OS's unless you provide custom scripts.
 
 This module uses puppet-lint, rubocop, rspec-puppet, beaker and travis-ci. We hope you use them before submitting your PR.
 
+Hopefully, you'll need rvm to get the correct gems installed (and not messing with your computer's Ruby setup). Pls follow [official installation instructions](https://rvm.io/rvm/install), plus:
+
+```Shell
+sudo usermod -aG rvm $USER
+echo 'source "/etc/profile.d/rvm.sh"' >> ~/.bashrc
+```
+
+Reboot for all changes to take effect
+
 ```shell
 gem install bundler --no-rdoc --no-ri
 bundle config set --local without 'development'

--- a/README.md
+++ b/README.md
@@ -941,7 +941,21 @@ sudo usermod -aG rvm $USER
 echo 'source "/etc/profile.d/rvm.sh"' >> ~/.bashrc
 ```
 
-Reboot for all changes to take effect
+Reboot for all changes to take effect, then install Ruby 2.7:
+
+```shell
+# Didn't work for installing Ruby 2.7, but looks wise:
+rvm autolibs enable
+# Ruby 2.7 dependency
+rvm pkg install openssl
+Beware, 'rvm pkg ...' is deprecated, read about the new autolibs feature: 'rvm help autolibs'.
+# Inside this project's root directory:
+rvm install ruby-2.7 --with-openssl-dir=/usr/share/rvm/usr
+rvm use ruby-2.7
+# Validate
+ruby -v
+ruby 2.7.x (20XX-YY-ZZ revision &lt;Hash&gt;) [x86_64-linux]
+```
 
 ```shell
 gem install bundler --no-rdoc --no-ri


### PR DESCRIPTION
Current gems are not compatible to Ruby >= 3.0.0, so we need to stick to 2.x, being 2.7 the latest. Also, it's hard to get the Gemfile's specific gem versions in recent systems without breaking lots of Ruby related stuff.

This change instructs on setting up a protected Ruby environment thru rvm, making the exact Gemfile setup possible, and protecting everything else in our computers.

Also, `gem install bundler` doesn't support the currently indicated flags anymore. This change updates the `--no-rdoc` flag as I think it's intended and remove the `--no-ri` flag, as I don't know what it does.

Lastly, fix trailing space errors.