### PR TITLE
Add parameter to set JAVA_OPTS option MaxMetaspaceSize - Fix #288

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
     * [Patch management](#patch-management)
     * [Unmanaged installation](#unmanaged-installation)
     * [Domain Mode](#domain-mode)
+    * [Java Virtual Machine options](#java-virtual-machine-options)
     * [Deployment](#deployment)
     * [User management](#user-management)
     * [Module installation](#module-installation)
@@ -570,6 +571,19 @@ fi
 if [ "x$HOST_CONTROLLER_JAVA_OPTS" = "x" ]; then
     HOST_CONTROLLER_JAVA_OPTS="$JAVA_OPTS <managed_opt_1> <managed_opt_2>"
 fi
+```
+
+### Java Virtual Machine options
+
+To adjust [JVM heap memory settings](https://www.baeldung.com/jvm-parameters#explicit-heap-memory---xms-and-xmx-options), use `wildfly` class `java_xmx`, `java_xms` and/or `java_maxmetaspace_size` parameters:
+
+```puppet
+class { 'wildfly':
+  # ...
+  java_xms               => '<Minimum heap size>',
+  java_xmx               => '<Maximum heap size>',
+  java_maxmetaspace_size => '<Maximum Metaspace size>',
+}
 ```
 
 ### Deployment

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ It should work on every operating system with the following init systems: sysvin
 
 ### wildfly class
 
-The main changes in `wildfly` class are bellow:
+The main changes in `wildfly` class are below:
 
 ```puppet
 class { '::wildfly':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,9 +19,10 @@
 # @param install_download_timeout Sets the timeout for installer download.
 # @param install_source Source of Wildfly tarball installer.
 # @param java_home Sets the `JAVA_HOME` for Wildfly.
-# @param java_opts Sets `JAVA_OPTS`, allowing to override several Java params, like `Xmx`, `Xms`,
+# @param java_opts Sets `JAVA_OPTS`, allowing to override several Java params, like `Xmx`, `Xms` and `MaxMetaspaceSize`,
 # @param java_xmx Sets Java's `-Xmx` parameter.
 # @param java_xms Sets Java's `-Xms` parameter.
+# @param java_maxmetaspace_size Sets Java's `-XX:MaxMetaspaceSize` parameter.
 # @param jboss_opts Sets `JBOSS_OPTS`, allowing to override several JBoss properties. It only works with Wildfly 8.2+.
 # @param manage_user Whether this module should manage wildfly user and group.
 # @param mgmt_user Hash containing a Wildfly's management user to be used internally.
@@ -83,6 +84,7 @@ class wildfly (
   Wildfly::Config_file                               $host_config                  = 'host.xml',
   String                                             $java_xmx                     = '512m',
   String                                             $java_xms                     = '256m',
+  String                                             $java_maxmetaspace_size       = '128m',
   String                                             $package_ensure               = 'present',
   Boolean                                            $service_ensure               = true,
   Boolean                                            $service_manage               = true,

--- a/templates/domain.conf.epp
+++ b/templates/domain.conf.epp
@@ -42,12 +42,12 @@ fi
 # Specify options to pass to the Java VM.
 #
 if [ "x$JAVA_OPTS" = "x" ]; then
-    JAVA_OPTS="-Xms<%= $wildfly::java_xms %> -Xmx<%= $wildfly::java_xmx %>"
+    JAVA_OPTS="-Xms<%= $wildfly::java_xms %> -Xmx<%= $wildfly::java_xmx %> -XX:MaxMetaspaceSize=<%= $wildfly::java_maxmetaspace_size %>"
     JAVA_OPTS="$JAVA_OPTS <% if $wildfly::java_opts =~ Array { -%>
 <%= $wildfly::java_opts.join(" ") -%>
 <% } elsif $wildfly::java_opts =~ String { -%>
 <%= $wildfly::java_opts -%>
-<% } -%>""
+<% } -%>"
 else
     echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
 fi

--- a/templates/standalone.conf.epp
+++ b/templates/standalone.conf.epp
@@ -47,7 +47,7 @@ fi
 # Specify options to pass to the Java VM.
 #
 if [ "x$JAVA_OPTS" = "x" ]; then
-   JAVA_OPTS="-Xms<%= $wildfly::java_xms %> -Xmx<%= $wildfly::java_xmx %>"
+   JAVA_OPTS="-Xms<%= $wildfly::java_xms %> -Xmx<%= $wildfly::java_xmx %> -XX:MaxMetaspaceSize=<%= $wildfly::java_maxmetaspace_size %>"
    JAVA_OPTS="$JAVA_OPTS <%= $wildfly::java_opts %>"
 else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"


### PR DESCRIPTION
This change add parameter `wildfly::java_maxmetaspace_size`, which sets [Java Virtual Machine maximum metaspace size](https://www.baeldung.com/jvm-parameters#explicit-heap-memory---xms-and-xmx-options), and adds example in README