### PR TITLE
Fix wildfly_resource path validation regex

### DIFF
--- a/lib/puppet/type/wildfly_resource.rb
+++ b/lib/puppet/type/wildfly_resource.rb
@@ -14,7 +14,7 @@ Puppet::Type.newtype(:wildfly_resource) do
     isnamevar
 
     validate do |value|
-      raise("Invalid resource path #{value}") unless value =~ %r{(\/[\w\-]+=[\w\-]+)}
+      raise("Invalid resource path #{value}") unless value =~ %r{\A(?:/[\w.-]+=(?:[\w.:/-]+|"[^"\\]*(?:\\.[^"\\]*)*"))+\z}
     end
   end
 
@@ -44,7 +44,7 @@ Puppet::Type.newtype(:wildfly_resource) do
 
   newparam(:secure) do
     desc 'Use TLS to connect with the management API'
-    defaultto false 
+    defaultto false
   end
 
   newparam(:recursive) do

--- a/spec/unit/puppet/type/wildfly_resource_spec.rb
+++ b/spec/unit/puppet/type/wildfly_resource_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:wildfly_resource) do
+  let(:resource_class) { Puppet::Type.type(:wildfly_resource) }
+
+  describe 'path validation' do
+    context 'with valid paths' do
+      [
+        '/system-property="app/config/path"',
+        '/system-property=log4j2.formatMsgNoLookups',
+        '/subsystem=modcluster/mod-cluster-config=configuration',
+        '/subsystem=datasources/data-source=java:jboss/datasources/ExampleDS',
+        '/core-service=management/security-realm=ApplicationRealm/server-identity=ssl',
+        '/subsystem=undertow/server=default-server/host=default-host/location=" / "',
+      ].each do |path|
+        it "accepts #{path}" do
+          expect do
+            resource_class.new(title: path, state: { 'value' => 'true' })
+          end.not_to raise_error
+        end
+      end
+    end
+
+    context 'with invalid paths' do
+      [
+        '/subsystem=modcluster/key=value=extra',
+        '/subsystem=modcluster/invalid!key=value',
+        '/subsystem=modcluster/key="unclosed-quote',
+        'subsystem=modcluster',
+        '/subsystem',
+        '/subsystem=modcluster/mod-cluster-config=',
+      ].each do |path|
+        it "rejects #{path}" do
+          expect do
+            resource_class.new(title: path, state: { 'value' => 'true' })
+          end.to raise_error(Puppet::Error, %r{Invalid resource path})
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Update the regex in `wildfly_resource` to allow forward slashes, dots, colons, and dashes in unquoted values, while maintaining robust support for slashes in quoted values.

The previous implementation was too restrictive and failed to validate standard Wildfly CLI paths, such as file paths or datasources (e.g., `data-source=java:jboss/datasources/ExampleDS`).

This change ensures valid paths are accepted while maintaining strict validation for the overall `key=value` structure.

* RSpec tests pass locally.
* Deployed and tested successfully against live Wildfly nodes.