### PR TITLE
chore: fqdn_rand_string deprecation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -359,7 +359,7 @@ Default value:
 ```puppet
 {
     username => 'puppet',
-    password => fqdn_rand_string(30),
+    password => stdlib::fqdn_rand_string(30),
   }
 ```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,7 +111,7 @@ class wildfly (
   },
   Struct[{ username => String, password => String }] $mgmt_user                    = {
     username => 'puppet',
-    password => fqdn_rand_string(30),
+    password => stdlib::fqdn_rand_string(30),
   },
   Boolean                                            $dnf_group_install            = false,
   Integer                                            $dnf_group_install_timeout    = 600,


### PR DESCRIPTION
switch to stdlib::fqnd_rand_string
