### PR TITLE
chore: switch to namespaced function

### DIFF
--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -36,6 +36,6 @@ class wildfly::prepare {
       default  => 'libaio',
     }
 
-    ensure_packages({ $libaiopackage => { 'ensure' => $wildfly::package_ensure } })
+    stdlib::ensure_packages({ $libaiopackage => { 'ensure' => $wildfly::package_ensure } })
   }
 }


### PR DESCRIPTION
ensure_packages is deprecated, use stdlib::ensure_packages